### PR TITLE
upd: add service upload_tft_url

### DIFF
--- a/nspanel_esphome.yaml
+++ b/nspanel_esphome.yaml
@@ -124,6 +124,14 @@ api:
     - service: upload_tft
       then:
         - lambda: 'id(disp1)->upload_tft();'
+
+    ##### SERVICE TO UPDATE THE TFT FILE from URL #####
+    - service: upload_tft_url
+      variables:
+        url: string
+      then:
+        - lambda: 'id(disp1)->set_tft_url(url.c_str());'
+        - lambda: 'id(disp1)->upload_tft();'
             
     ##### Service to send a command "printf" directly to the display #####
     - service: send_command_printf


### PR DESCRIPTION
Add an additional service to upload tft from url via parameter to make it easier to e.g. install blank.tft without need to recompile esphome.