### PR TITLE
Fix default language

### DIFF
--- a/nspanel_blueprint.yaml
+++ b/nspanel_blueprint.yaml
@@ -54,7 +54,7 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
     language:
       name: Language for NSPanel
       description: '* *select the language for your NSPanel*'
-      default: 'EN'
+      default: 'ENG'
       selector:
         select:
           mode: dropdown


### PR DESCRIPTION
The default value for language should be aligned to one of the options, so it will use it when no language selection is made.