### PR TITLE
Fix default language input

### DIFF
--- a/nspanel_blueprint.yaml
+++ b/nspanel_blueprint.yaml
@@ -54,7 +54,7 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
     language:
       name: Language for NSPanel
       description: '* *select the language for your NSPanel*'
-      default: 'EN'
+      default: 'ENG'
       selector:
         select:
           mode: dropdown


### PR DESCRIPTION
Fix default language so it can be used when no selection is done (like when upgrading from earlier version when language input was not available).