### PR TITLE
Convert "Update TFT display" into a button

### DIFF
--- a/nspanel_esphome.yaml
+++ b/nspanel_esphome.yaml
@@ -107,12 +107,22 @@ uart:
   baud_rate: 115200
   id: tf_uart
 
-###### REBOOT BUTTON #####
+##### START - BUTTON CONFIGURATION #####
 button:
+  ###### REBOOT BUTTON #####
   - platform: restart
     name: ${device_name} Restart
     id: restart_nspanel
 
+  ##### UPDATE TFT DISPLAY #####
+  - platform: template
+    name: ${device_name} Update TFT display
+    icon: mdi:file-sync
+    id: tft_update
+    entity_category: config
+    on_press:
+      - delay: 16ms
+      - lambda: id(disp1).upload_tft();
 
 ##### START - API CONFIGURATION #####
 api:
@@ -747,16 +757,6 @@ switch:
     entity_category: config
     restore_state: false
     optimistic: true
-
-  ##### UPDATE TFT DISPLAY #####
-  - platform: template
-    name: ${device_name} Update TFT display
-    id: tft_update
-    entity_category: config
-    turn_on_action:
-      - delay: 16ms
-      - lambda: id(disp1).upload_tft();
-      - switch.turn_off: tft_update
 
   ##### PHYSICAL SWITCH 1 #####
   - platform: gpio


### PR DESCRIPTION
* This is a breaking change. Existing automation using the Switch version will need an update to use the button version instead.

This was originally set as a switch, but in reality it behaves as a button, as when the user click it runs an action (in this case, update the TFT display file). Switches should be used only when an entity will remain in one of the two states (on/off), which is not the case here.

This is related to #328.