### PR TITLE
Compile limit

### DIFF
--- a/nspanel_esphome.yaml
+++ b/nspanel_esphome.yaml
@@ -16,6 +16,7 @@
   # web_password: !secret nspanel_web_password # add in your esphome secrets file. - manual change in code required to activate
   # api_password: !secret nspanel_api_password # add in your esphome secrets file. - manual change in code required to activate
   # nextion_update_url: !secret nspanel_update_url # add in your esphome secrets file. Example: "http://"HOME ASSISTANT IP":8123/local/nspanel/nspanel.tft"
+  # compile_process_limit: "1"
 
   # ## static ip config ##
   # ip: "10.0.0.7"
@@ -58,6 +59,7 @@ external_components:
 esphome:
   name: ${device_name}
   min_version: 2022.10.2
+  compile_process_limit: ${compile_process_limit}
 
 ##### TYPE OF ESP BOARD #####
 esp32:


### PR DESCRIPTION
Add compile_process_limit to esphome: and in this way you can compile with 1GB of RAM.
Also the code in the wiki needs to be updated
substitutions:

###### CHANGE ME START ######

  device_name: "YOUR NSPANEL_NAME" 
  wifi_ssid: "YOUR WIFI SSID"
  wifi_password: "YOUR WIFI PASSWORD"
 compile_process_limit: "1"

  nextion_update_url: "http://HOME-ASSISTANT-IP:8123/local/nspanel_us.tft" # URL to local tft File
#  nextion_update_url: "https://raw.githubusercontent.com/Blackymas/NSPanel_HA_Blueprint/main/nspanel_us.tft" # URL to Github

##### CHANGE ME END #####



##### DO NOT CHANGE ANYTHING! #####

packages:
  ##### download esphome code from Github
  remote_package:
    url: https://github.com/Blackymas/NSPanel_HA_Blueprint
    ref: main
    files: [nspanel_esphome.yaml]
    refresh: 300s

##### DO NOT CHANGE ANYTHING! #####