### PR TITLE
Fix warning: 'heating_bt_pic_on' is undefined

### DIFF
--- a/nspanel_blueprint.yaml
+++ b/nspanel_blueprint.yaml
@@ -3103,6 +3103,9 @@ variables:
   hotw_bt_off: "80"
   hotw_bt_on: "81"
 
+  # heating_bt_pic
+  heating_bt_pic_off: "103"
+  heating_bt_pic_on: "104"
 
 
 ##### CHANGE ME START ##########################################################################################################


### PR DESCRIPTION
Fix warning in log:
```
Template variable warning: 'heating_bt_pic_on' is undefined when rendering '{%- if hvac_mode == "off" -%} {{ heating_bt_pic_off }} {%- else -%} {{ heating_bt_pic_on }} {%- endif -%}'
Template variable warning: 'heating_bt_pic_on' is undefined when rendering '{%- if trigger.event.data.new_state.state == "off" -%} {{ heating_bt_pic_off }} {%- else -%} {{ heating_bt_pic_on }} {%- endif -%}'
```
These variables were present on v3.1 and was removed on v3.2, but this caused an error as those are still used by the Blueprint.