### PR TITLE
Fix so homepage works when one of home values 01-03 is unavailable.

### DIFF
--- a/nspanel_blueprint.yaml
+++ b/nspanel_blueprint.yaml
@@ -5005,7 +5005,7 @@ action:
                       sequence:
                         - if:
                             - condition: template
-                              value_template: '{{ repeat.item.entity is match "sensor." and states(repeat.item.entity).state != "unavailable" }}'
+                              value_template: '{{ repeat.item.entity is match "sensor." and states(repeat.item.entity) != "unavailable" }}'
                           then:
                             - if:
                                 - condition: template


### PR DESCRIPTION
Seems unavailable sensors break the homepage. Noticed this when mine always did go dead after sunset. My solar inverter turns off then and sensors become unavailable. Here is a proposed fix.