### PR TITLE
Introducing color names

### DIFF
--- a/nspanel_blueprint.yaml
+++ b/nspanel_blueprint.yaml
@@ -3107,13 +3107,25 @@ variables:
 
 ##### CHANGE ME START ##########################################################################################################
   ###### GENERAL - NEXTION COLOR MAPPING #####
-  color_01: "65535" #White
-  color_02: "10597" #Grey dark
-  color_03: "33808" #Grey light
-  color_04: "1055" #Blue
-  color_05: "63488" #Red
-  color_06: "52857" #Grey super light
-  color_07: "65472" #Yellow
+  #color_01: "65535" #White
+  #color_02: "10597" #Grey dark
+  #color_03: "33808" #Grey light
+  #color_04: "1055" #Blue
+  #color_05: "63488" #Red
+  #color_06: "52857" #Grey super light
+  #color_07: "65472" #Yellow
+  nextion_colors: ## Nextion docs: https://nextion.tech/instruction-set/ (item 5 - Color code constants)
+    black: 0
+    blue: 1055
+    brown: 48192
+    gray: 33840
+    graydark: 10597
+    graylight: 33808
+    graysuperlight: 52857
+    green: 2016
+    red: 63488
+    white: 65535
+    yellow: 65472
 
   ###### "GENERAL" NEXTION FONT ICON MAPPING #####
   blank_icon: "\U0000FFFF" #blank macbook bug
@@ -5050,7 +5062,7 @@ action:
                       set_button04_icon_font: >-
                         {%- if is_state(notification_unread, 'on') and states(notification_text) |length > 0 -%} {{ home_button04_icon_color01 }}
                         {%- elif is_state(notification_unread, 'off') and states(notification_text) |length > 0 -%} {{ home_button04_icon_color02 }}
-                        {%- else -%} {{ color_03 }}
+                        {%- else -%} {{ nextion_colors.graylight }}
                         {%- endif -%}
                   ##### SET ICON Font - Notify #####
                   - delay:
@@ -5214,39 +5226,39 @@ action:
                                   {%- endif -%}
                                 # TEXT, BRIGHTNESS and ICON Background
                                 btn_bg: >-
-                                  {%- if current_entity_state == 'unknown' or current_entity_state == 'unavailable' -%} {{ color_02 }}
-                                  {%- elif repeat.item.entity is match "button." or repeat.item.entity is match "input_button." or repeat.item.entity is match "scene." -%} {{ color_02 }}
-                                  {%- elif current_entity_state == 'on' or current_entity_state == 'open' -%} {{ color_01 }}
-                                  {%- elif current_entity_state == 'off' or current_entity_state == 'closed' -%} {{ color_02 }}
-                                  {%- elif repeat.item.entity is match "person." and current_entity_state == 'home' -%} {{ color_01 }}
-                                  {%- elif repeat.item.entity is match "person." and current_entity_state != 'home' -%} {{ color_02 }}
-                                  {%- elif repeat.item.entity is match "climate." and current_entity_state != 'off' -%} {{ color_01 }}
-                                  {%- elif repeat.item.entity is match "climate." and current_entity_state == 'off' -%} {{ color_02 }}
+                                  {%- if current_entity_state == 'unknown' or current_entity_state == 'unavailable' -%} {{ nextion_colors.graydark }}
+                                  {%- elif repeat.item.entity is match "button." or repeat.item.entity is match "input_button." or repeat.item.entity is match "scene." -%} {{ nextion_colors.graydark }}
+                                  {%- elif current_entity_state == 'on' or current_entity_state == 'open' -%} {{ nextion_colors.white }}
+                                  {%- elif current_entity_state == 'off' or current_entity_state == 'closed' -%} {{ nextion_colors.graydark }}
+                                  {%- elif repeat.item.entity is match "person." and current_entity_state == 'home' -%} {{ nextion_colors.white }}
+                                  {%- elif repeat.item.entity is match "person." and current_entity_state != 'home' -%} {{ nextion_colors.graydark }}
+                                  {%- elif repeat.item.entity is match "climate." and current_entity_state != 'off' -%} {{ nextion_colors.white }}
+                                  {%- elif repeat.item.entity is match "climate." and current_entity_state == 'off' -%} {{ nextion_colors.graydark }}
                                   {%- endif -%}
                                 # ICON Font Color
                                 btn_icon_font: >-
-                                  {%- if current_entity_state == 'unknown' or current_entity_state == 'unavailable' -%} {{ color_05 }}
-                                  {%- elif repeat.item.entity is match "button." or repeat.item.entity is match "input_button." or repeat.item.entity is match "scene." -%} {{ color_03 }}
+                                  {%- if current_entity_state == 'unknown' or current_entity_state == 'unavailable' -%} {{ nextion_colors.red }}
+                                  {%- elif repeat.item.entity is match "button." or repeat.item.entity is match "input_button." or repeat.item.entity is match "scene." -%} {{ nextion_colors.graylight }}
                                   {%- elif current_entity_state == 'on' or current_entity_state == 'open' -%} {{ repeat.item.button_icon_color }}
-                                  {%- elif current_entity_state == 'off' or current_entity_state == 'closed' -%} {{ color_03 }}
+                                  {%- elif current_entity_state == 'off' or current_entity_state == 'closed' -%} {{ nextion_colors.graylight }}
                                   {%- elif repeat.item.entity is match "person." and current_entity_state == 'home' -%} {{ repeat.item.button_icon_color }}
-                                  {%- elif repeat.item.entity is match "person." and current_entity_state != 'home' -%} {{ color_03 }}
+                                  {%- elif repeat.item.entity is match "person." and current_entity_state != 'home' -%} {{ nextion_colors.graylight }}
                                   {%- elif repeat.item.entity is match "climate." and current_entity_state != 'off' -%} {{ repeat.item.button_icon_color }}
-                                  {%- elif repeat.item.entity is match "climate." and current_entity_state == 'off' -%} {{ color_03 }}
+                                  {%- elif repeat.item.entity is match "climate." and current_entity_state == 'off' -%} {{ nextion_colors.graylight }}
                                   {%- endif -%}
                                 # LABEL Font Color
                                 btn_txt_font: >-
-                                  {%- if current_entity_state == 'unknown' or current_entity_state == 'unavailable' -%} {{ color_01 }}
-                                  {%- elif repeat.item.entity is match "button." or repeat.item.entity is match "input_button." or repeat.item.entity is match "scene." -%} {{ color_01 }}
-                                  {%- elif current_entity_state == 'on' or current_entity_state == 'open' -%} {{ color_02 }}
-                                  {%- elif current_entity_state == 'off' or current_entity_state == 'closed' -%} {{ color_01 }}
-                                  {%- elif repeat.item.entity is match "person." and current_entity_state == 'home' -%} {{ color_02 }}
-                                  {%- elif repeat.item.entity is match "person." and current_entity_state != 'home' -%} {{ color_01 }}
-                                  {%- elif repeat.item.entity is match "climate." and current_entity_state != 'off' -%} {{ color_02 }}
-                                  {%- elif repeat.item.entity is match "climate." and current_entity_state == 'off' -%} {{ color_01 }}
+                                  {%- if current_entity_state == 'unknown' or current_entity_state == 'unavailable' -%} {{ nextion_colors.white }}
+                                  {%- elif repeat.item.entity is match "button." or repeat.item.entity is match "input_button." or repeat.item.entity is match "scene." -%} {{ nextion_colors.white }}
+                                  {%- elif current_entity_state == 'on' or current_entity_state == 'open' -%} {{ nextion_colors.graydark }}
+                                  {%- elif current_entity_state == 'off' or current_entity_state == 'closed' -%} {{ nextion_colors.white }}
+                                  {%- elif repeat.item.entity is match "person." and current_entity_state == 'home' -%} {{ nextion_colors.graydark }}
+                                  {%- elif repeat.item.entity is match "person." and current_entity_state != 'home' -%} {{ nextion_colors.white }}
+                                  {%- elif repeat.item.entity is match "climate." and current_entity_state != 'off' -%} {{ nextion_colors.graydark }}
+                                  {%- elif repeat.item.entity is match "climate." and current_entity_state == 'off' -%} {{ nextion_colors.white }}
                                   {%- endif -%}
                                 # BRIGHTNESS Font Color
-                                btn_bri_font: "{{ color_02 }}"
+                                btn_bri_font: "{{ nextion_colors.graydark }}"
                                 # ICON Value
                                 btn_icon: >-
                                   {%- if current_entity_state == 'unknown' or current_entity_state == 'unavailable' -%} {{ button_icon_unknown }}
@@ -5465,39 +5477,39 @@ action:
                                   {%- endif -%}
                                 # TEXT, BRIGHTNESS and ICON Background
                                 btn_bg: >-
-                                  {%- if current_entity_state == 'unknown' or current_entity_state == 'unavailable' -%} {{ color_02 }}
-                                  {%- elif repeat.item.entity is match "button." or repeat.item.entity is match "input_button." or repeat.item.entity is match "scene." -%} {{ color_02 }}
-                                  {%- elif current_entity_state == 'on' or current_entity_state == 'open' -%} {{ color_01 }}
-                                  {%- elif current_entity_state == 'off' or current_entity_state == 'closed' -%} {{ color_02 }}
-                                  {%- elif repeat.item.entity is match "person." and current_entity_state == 'home' -%} {{ color_01 }}
-                                  {%- elif repeat.item.entity is match "person." and current_entity_state != 'home' -%} {{ color_02 }}
-                                  {%- elif repeat.item.entity is match "climate." and current_entity_state != 'off' -%} {{ color_01 }}
-                                  {%- elif repeat.item.entity is match "climate." and current_entity_state == 'off' -%} {{ color_02 }}
+                                  {%- if current_entity_state == 'unknown' or current_entity_state == 'unavailable' -%} {{ nextion_colors.graydark }}
+                                  {%- elif repeat.item.entity is match "button." or repeat.item.entity is match "input_button." or repeat.item.entity is match "scene." -%} {{ nextion_colors.graydark }}
+                                  {%- elif current_entity_state == 'on' or current_entity_state == 'open' -%} {{ nextion_colors.white }}
+                                  {%- elif current_entity_state == 'off' or current_entity_state == 'closed' -%} {{ nextion_colors.graydark }}
+                                  {%- elif repeat.item.entity is match "person." and current_entity_state == 'home' -%} {{ nextion_colors.white }}
+                                  {%- elif repeat.item.entity is match "person." and current_entity_state != 'home' -%} {{ nextion_colors.graydark }}
+                                  {%- elif repeat.item.entity is match "climate." and current_entity_state != 'off' -%} {{ nextion_colors.white }}
+                                  {%- elif repeat.item.entity is match "climate." and current_entity_state == 'off' -%} {{ nextion_colors.graydark }}
                                   {%- endif -%}
                                 # ICON Font Color
                                 btn_icon_font: >-
-                                  {%- if current_entity_state == 'unknown' or current_entity_state == 'unavailable' -%} {{ color_05 }}
-                                  {%- elif repeat.item.entity is match "button." or repeat.item.entity is match "input_button." or repeat.item.entity is match "scene." -%} {{ color_03 }}
+                                  {%- if current_entity_state == 'unknown' or current_entity_state == 'unavailable' -%} {{ nextion_colors.red }}
+                                  {%- elif repeat.item.entity is match "button." or repeat.item.entity is match "input_button." or repeat.item.entity is match "scene." -%} {{ nextion_colors.graylight }}
                                   {%- elif current_entity_state == 'on' or current_entity_state == 'open' -%} {{ repeat.item.button_icon_color }}
-                                  {%- elif current_entity_state == 'off' or current_entity_state == 'closed' -%} {{ color_03 }}
+                                  {%- elif current_entity_state == 'off' or current_entity_state == 'closed' -%} {{ nextion_colors.graylight }}
                                   {%- elif repeat.item.entity is match "person." and current_entity_state == 'home' -%} {{ repeat.item.button_icon_color }}
-                                  {%- elif repeat.item.entity is match "person." and current_entity_state != 'home' -%} {{ color_03 }}
+                                  {%- elif repeat.item.entity is match "person." and current_entity_state != 'home' -%} {{ nextion_colors.graylight }}
                                   {%- elif repeat.item.entity is match "climate." and current_entity_state != 'off' -%} {{ repeat.item.button_icon_color }}
-                                  {%- elif repeat.item.entity is match "climate." and current_entity_state == 'off' -%} {{ color_03 }}
+                                  {%- elif repeat.item.entity is match "climate." and current_entity_state == 'off' -%} {{ nextion_colors.graylight }}
                                   {%- endif -%}
                                 # LABEL Font Color
                                 btn_txt_font: >-
-                                  {%- if current_entity_state == 'unknown' or current_entity_state == 'unavailable' -%} {{ color_01 }}
-                                  {%- elif repeat.item.entity is match "button." or repeat.item.entity is match "input_button." or repeat.item.entity is match "scene." -%} {{ color_01 }}
-                                  {%- elif current_entity_state == 'on' or current_entity_state == 'open' -%} {{ color_02 }}
-                                  {%- elif current_entity_state == 'off' or current_entity_state == 'closed' -%} {{ color_01 }}
-                                  {%- elif repeat.item.entity is match "person." and current_entity_state == 'home' -%} {{ color_02 }}
-                                  {%- elif repeat.item.entity is match "person." and current_entity_state != 'home' -%} {{ color_01 }}
-                                  {%- elif repeat.item.entity is match "climate." and current_entity_state != 'off' -%} {{ color_02 }}
-                                  {%- elif repeat.item.entity is match "climate." and current_entity_state == 'off' -%} {{ color_01 }}
+                                  {%- if current_entity_state == 'unknown' or current_entity_state == 'unavailable' -%} {{ nextion_colors.white }}
+                                  {%- elif repeat.item.entity is match "button." or repeat.item.entity is match "input_button." or repeat.item.entity is match "scene." -%} {{ nextion_colors.white }}
+                                  {%- elif current_entity_state == 'on' or current_entity_state == 'open' -%} {{ nextion_colors.graydark }}
+                                  {%- elif current_entity_state == 'off' or current_entity_state == 'closed' -%} {{ nextion_colors.white }}
+                                  {%- elif repeat.item.entity is match "person." and current_entity_state == 'home' -%} {{ nextion_colors.graydark }}
+                                  {%- elif repeat.item.entity is match "person." and current_entity_state != 'home' -%} {{ nextion_colors.white }}
+                                  {%- elif repeat.item.entity is match "climate." and current_entity_state != 'off' -%} {{ nextion_colors.graydark }}
+                                  {%- elif repeat.item.entity is match "climate." and current_entity_state == 'off' -%} {{ nextion_colors.white }}
                                   {%- endif -%}
                                 # BRIGHTNESS Font Color
-                                btn_bri_font: "{{ color_02 }}"
+                                btn_bri_font: "{{ nextion_colors.graydark }}"
                                 # ICON Value
                                 btn_icon: >-
                                   {%- if current_entity_state == 'unknown' or current_entity_state == 'unavailable' -%} {{ button_icon_unknown }}
@@ -5716,39 +5728,39 @@ action:
                                   {%- endif -%}
                                 # TEXT, BRIGHTNESS and ICON Background
                                 btn_bg: >-
-                                  {%- if current_entity_state == 'unknown' or current_entity_state == 'unavailable' -%} {{ color_02 }}
-                                  {%- elif repeat.item.entity is match "button." or repeat.item.entity is match "input_button." or repeat.item.entity is match "scene." -%} {{ color_02 }}
-                                  {%- elif current_entity_state == 'on' or current_entity_state == 'open' -%} {{ color_01 }}
-                                  {%- elif current_entity_state == 'off' or current_entity_state == 'closed' -%} {{ color_02 }}
-                                  {%- elif repeat.item.entity is match "person." and current_entity_state == 'home' -%} {{ color_01 }}
-                                  {%- elif repeat.item.entity is match "person." and current_entity_state != 'home' -%} {{ color_02 }}
-                                  {%- elif repeat.item.entity is match "climate." and current_entity_state != 'off' -%} {{ color_01 }}
-                                  {%- elif repeat.item.entity is match "climate." and current_entity_state == 'off' -%} {{ color_02 }}
+                                  {%- if current_entity_state == 'unknown' or current_entity_state == 'unavailable' -%} {{ nextion_colors.graydark }}
+                                  {%- elif repeat.item.entity is match "button." or repeat.item.entity is match "input_button." or repeat.item.entity is match "scene." -%} {{ nextion_colors.graydark }}
+                                  {%- elif current_entity_state == 'on' or current_entity_state == 'open' -%} {{ nextion_colors.white }}
+                                  {%- elif current_entity_state == 'off' or current_entity_state == 'closed' -%} {{ nextion_colors.graydark }}
+                                  {%- elif repeat.item.entity is match "person." and current_entity_state == 'home' -%} {{ nextion_colors.white }}
+                                  {%- elif repeat.item.entity is match "person." and current_entity_state != 'home' -%} {{ nextion_colors.graydark }}
+                                  {%- elif repeat.item.entity is match "climate." and current_entity_state != 'off' -%} {{ nextion_colors.white }}
+                                  {%- elif repeat.item.entity is match "climate." and current_entity_state == 'off' -%} {{ nextion_colors.graydark }}
                                   {%- endif -%}
                                 # ICON Font Color
                                 btn_icon_font: >-
-                                  {%- if current_entity_state == 'unknown' or current_entity_state == 'unavailable' -%} {{ color_05 }}
-                                  {%- elif repeat.item.entity is match "button." or repeat.item.entity is match "input_button." or repeat.item.entity is match "scene." -%} {{ color_03 }}
+                                  {%- if current_entity_state == 'unknown' or current_entity_state == 'unavailable' -%} {{ nextion_colors.red }}
+                                  {%- elif repeat.item.entity is match "button." or repeat.item.entity is match "input_button." or repeat.item.entity is match "scene." -%} {{ nextion_colors.graylight }}
                                   {%- elif current_entity_state == 'on' or current_entity_state == 'open' -%} {{ repeat.item.button_icon_color }}
-                                  {%- elif current_entity_state == 'off' or current_entity_state == 'closed' -%} {{ color_03 }}
+                                  {%- elif current_entity_state == 'off' or current_entity_state == 'closed' -%} {{ nextion_colors.graylight }}
                                   {%- elif repeat.item.entity is match "person." and current_entity_state == 'home' -%} {{ repeat.item.button_icon_color }}
-                                  {%- elif repeat.item.entity is match "person." and current_entity_state != 'home' -%} {{ color_03 }}
+                                  {%- elif repeat.item.entity is match "person." and current_entity_state != 'home' -%} {{ nextion_colors.graylight }}
                                   {%- elif repeat.item.entity is match "climate." and current_entity_state != 'off' -%} {{ repeat.item.button_icon_color }}
-                                  {%- elif repeat.item.entity is match "climate." and current_entity_state == 'off' -%} {{ color_03 }}
+                                  {%- elif repeat.item.entity is match "climate." and current_entity_state == 'off' -%} {{ nextion_colors.graylight }}
                                   {%- endif -%}
                                 # LABEL Font Color
                                 btn_txt_font: >-
-                                  {%- if current_entity_state == 'unknown' or current_entity_state == 'unavailable' -%} {{ color_01 }}
-                                  {%- elif repeat.item.entity is match "button." or repeat.item.entity is match "input_button." or repeat.item.entity is match "scene." -%} {{ color_01 }}
-                                  {%- elif current_entity_state == 'on' or current_entity_state == 'open' -%} {{ color_02 }}
-                                  {%- elif current_entity_state == 'off' or current_entity_state == 'closed' -%} {{ color_01 }}
-                                  {%- elif repeat.item.entity is match "person." and current_entity_state == 'home' -%} {{ color_02 }}
-                                  {%- elif repeat.item.entity is match "person." and current_entity_state != 'home' -%} {{ color_01 }}
-                                  {%- elif repeat.item.entity is match "climate." and current_entity_state != 'off' -%} {{ color_02 }}
-                                  {%- elif repeat.item.entity is match "climate." and current_entity_state == 'off' -%} {{ color_01 }}
+                                  {%- if current_entity_state == 'unknown' or current_entity_state == 'unavailable' -%} {{ nextion_colors.white }}
+                                  {%- elif repeat.item.entity is match "button." or repeat.item.entity is match "input_button." or repeat.item.entity is match "scene." -%} {{ nextion_colors.white }}
+                                  {%- elif current_entity_state == 'on' or current_entity_state == 'open' -%} {{ nextion_colors.graydark }}
+                                  {%- elif current_entity_state == 'off' or current_entity_state == 'closed' -%} {{ nextion_colors.white }}
+                                  {%- elif repeat.item.entity is match "person." and current_entity_state == 'home' -%} {{ nextion_colors.graydark }}
+                                  {%- elif repeat.item.entity is match "person." and current_entity_state != 'home' -%} {{ nextion_colors.white }}
+                                  {%- elif repeat.item.entity is match "climate." and current_entity_state != 'off' -%} {{ nextion_colors.graydark }}
+                                  {%- elif repeat.item.entity is match "climate." and current_entity_state == 'off' -%} {{ nextion_colors.white }}
                                   {%- endif -%}
                                 # BRIGHTNESS Font Color
-                                btn_bri_font: "{{ color_02 }}"
+                                btn_bri_font: "{{ nextion_colors.graydark }}"
                                 # ICON Value
                                 btn_icon: >-
                                   {%- if current_entity_state == 'unknown' or current_entity_state == 'unavailable' -%} {{ button_icon_unknown }}
@@ -5967,39 +5979,39 @@ action:
                                   {%- endif -%}
                                 # TEXT, BRIGHTNESS and ICON Background
                                 btn_bg: >-
-                                  {%- if current_entity_state == 'unknown' or current_entity_state == 'unavailable' -%} {{ color_02 }}
-                                  {%- elif repeat.item.entity is match "button." or repeat.item.entity is match "input_button." or repeat.item.entity is match "scene." -%} {{ color_02 }}
-                                  {%- elif current_entity_state == 'on' or current_entity_state == 'open' -%} {{ color_01 }}
-                                  {%- elif current_entity_state == 'off' or current_entity_state == 'closed' -%} {{ color_02 }}
-                                  {%- elif repeat.item.entity is match "person." and current_entity_state == 'home' -%} {{ color_01 }}
-                                  {%- elif repeat.item.entity is match "person." and current_entity_state != 'home' -%} {{ color_02 }}
-                                  {%- elif repeat.item.entity is match "climate." and current_entity_state != 'off' -%} {{ color_01 }}
-                                  {%- elif repeat.item.entity is match "climate." and current_entity_state == 'off' -%} {{ color_02 }}
+                                  {%- if current_entity_state == 'unknown' or current_entity_state == 'unavailable' -%} {{ nextion_colors.graydark }}
+                                  {%- elif repeat.item.entity is match "button." or repeat.item.entity is match "input_button." or repeat.item.entity is match "scene." -%} {{ nextion_colors.graydark }}
+                                  {%- elif current_entity_state == 'on' or current_entity_state == 'open' -%} {{ nextion_colors.white }}
+                                  {%- elif current_entity_state == 'off' or current_entity_state == 'closed' -%} {{ nextion_colors.graydark }}
+                                  {%- elif repeat.item.entity is match "person." and current_entity_state == 'home' -%} {{ nextion_colors.white }}
+                                  {%- elif repeat.item.entity is match "person." and current_entity_state != 'home' -%} {{ nextion_colors.graydark }}
+                                  {%- elif repeat.item.entity is match "climate." and current_entity_state != 'off' -%} {{ nextion_colors.white }}
+                                  {%- elif repeat.item.entity is match "climate." and current_entity_state == 'off' -%} {{ nextion_colors.graydark }}
                                   {%- endif -%}
                                 # ICON Font Color
                                 btn_icon_font: >-
-                                  {%- if current_entity_state == 'unknown' or current_entity_state == 'unavailable' -%} {{ color_05 }}
-                                  {%- elif repeat.item.entity is match "button." or repeat.item.entity is match "input_button." or repeat.item.entity is match "scene." -%} {{ color_03 }}
+                                  {%- if current_entity_state == 'unknown' or current_entity_state == 'unavailable' -%} {{ nextion_colors.red }}
+                                  {%- elif repeat.item.entity is match "button." or repeat.item.entity is match "input_button." or repeat.item.entity is match "scene." -%} {{ nextion_colors.graylight }}
                                   {%- elif current_entity_state == 'on' or current_entity_state == 'open' -%} {{ repeat.item.button_icon_color }}
-                                  {%- elif current_entity_state == 'off' or current_entity_state == 'closed' -%} {{ color_03 }}
+                                  {%- elif current_entity_state == 'off' or current_entity_state == 'closed' -%} {{ nextion_colors.graylight }}
                                   {%- elif repeat.item.entity is match "person." and current_entity_state == 'home' -%} {{ repeat.item.button_icon_color }}
-                                  {%- elif repeat.item.entity is match "person." and current_entity_state != 'home' -%} {{ color_03 }}
+                                  {%- elif repeat.item.entity is match "person." and current_entity_state != 'home' -%} {{ nextion_colors.graylight }}
                                   {%- elif repeat.item.entity is match "climate." and current_entity_state != 'off' -%} {{ repeat.item.button_icon_color }}
-                                  {%- elif repeat.item.entity is match "climate." and current_entity_state == 'off' -%} {{ color_03 }}
+                                  {%- elif repeat.item.entity is match "climate." and current_entity_state == 'off' -%} {{ nextion_colors.graylight }}
                                   {%- endif -%}
                                 # LABEL Font Color
                                 btn_txt_font: >-
-                                  {%- if current_entity_state == 'unknown' or current_entity_state == 'unavailable' -%} {{ color_01 }}
-                                  {%- elif repeat.item.entity is match "button." or repeat.item.entity is match "input_button." or repeat.item.entity is match "scene." -%} {{ color_01 }}
-                                  {%- elif current_entity_state == 'on' or current_entity_state == 'open' -%} {{ color_02 }}
-                                  {%- elif current_entity_state == 'off' or current_entity_state == 'closed' -%} {{ color_01 }}
-                                  {%- elif repeat.item.entity is match "person." and current_entity_state == 'home' -%} {{ color_02 }}
-                                  {%- elif repeat.item.entity is match "person." and current_entity_state != 'home' -%} {{ color_01 }}
-                                  {%- elif repeat.item.entity is match "climate." and current_entity_state != 'off' -%} {{ color_02 }}
-                                  {%- elif repeat.item.entity is match "climate." and current_entity_state == 'off' -%} {{ color_01 }}
+                                  {%- if current_entity_state == 'unknown' or current_entity_state == 'unavailable' -%} {{ nextion_colors.white }}
+                                  {%- elif repeat.item.entity is match "button." or repeat.item.entity is match "input_button." or repeat.item.entity is match "scene." -%} {{ nextion_colors.white }}
+                                  {%- elif current_entity_state == 'on' or current_entity_state == 'open' -%} {{ nextion_colors.graydark }}
+                                  {%- elif current_entity_state == 'off' or current_entity_state == 'closed' -%} {{ nextion_colors.white }}
+                                  {%- elif repeat.item.entity is match "person." and current_entity_state == 'home' -%} {{ nextion_colors.graydark }}
+                                  {%- elif repeat.item.entity is match "person." and current_entity_state != 'home' -%} {{ nextion_colors.white }}
+                                  {%- elif repeat.item.entity is match "climate." and current_entity_state != 'off' -%} {{ nextion_colors.graydark }}
+                                  {%- elif repeat.item.entity is match "climate." and current_entity_state == 'off' -%} {{ nextion_colors.white }}
                                   {%- endif -%}
                                 # BRIGHTNESS Font Color
-                                btn_bri_font: "{{ color_02 }}"
+                                btn_bri_font: "{{ nextion_colors.graydark }}"
                                 # ICON Value
                                 btn_icon: >-
                                   {%- if current_entity_state == 'unknown' or current_entity_state == 'unavailable' -%} {{ button_icon_unknown }}
@@ -6135,7 +6147,7 @@ action:
                         {%- endif -%}
                       lightsettings_icon_font_color: >-
                         {%- if states(entity_long) == 'on' -%} {{ entity_long_icon_color }}
-                        {%- else -%} {{ color_03 }}
+                        {%- else -%} {{ nextion_colors.graylight }}
                         {%- endif -%}
                   - delay:
                       milliseconds: "{{ delay_value }}"
@@ -6227,7 +6239,7 @@ action:
                         {%- endif -%}
                       coversettings_icon_font_color: >-
                         {%- if states(entity_long) == 'open' -%} {{ entity_long_icon_color }}
-                        {%- else -%} {{ color_03 }}
+                        {%- else -%} {{ nextion_colors.graylight }}
                         {%- endif -%}
                   - delay:
                       milliseconds: "{{ delay_value }}"
@@ -8107,13 +8119,13 @@ action:
                 {%- endif -%}
               # TEXT and BRIGHTNESS and ICON Background
               btn_bg: >-
-                {%- if trigger.to_state.entity_id is match "button." or trigger.to_state.entity_id is match "input_button." or trigger.to_state.entity_id is match "scene." -%} {{ color_01 }}
-                {%- elif trigger.to_state.state == 'on' or trigger.to_state.state == 'open' -%} {{ color_01 }}
-                {%- elif trigger.to_state.state == 'off' or trigger.to_state.state == 'closed' -%} {{ color_02 }}
-                {%- elif trigger.to_state.entity_id is match "person." and trigger.to_state.state == 'home' -%} {{ color_01 }}
-                {%- elif trigger.to_state.entity_id is match "person." and trigger.to_state.state != 'home' -%} {{ color_02 }}
-                {%- elif trigger.to_state.entity_id is match "climate." and trigger.to_state.state != 'off' -%} {{ color_01 }}
-                {%- elif trigger.to_state.entity_id is match "climate." and trigger.to_state.state == 'off' -%} {{ color_02 }}
+                {%- if trigger.to_state.entity_id is match "button." or trigger.to_state.entity_id is match "input_button." or trigger.to_state.entity_id is match "scene." -%} {{ nextion_colors.white }}
+                {%- elif trigger.to_state.state == 'on' or trigger.to_state.state == 'open' -%} {{ nextion_colors.white }}
+                {%- elif trigger.to_state.state == 'off' or trigger.to_state.state == 'closed' -%} {{ nextion_colors.graydark }}
+                {%- elif trigger.to_state.entity_id is match "person." and trigger.to_state.state == 'home' -%} {{ nextion_colors.white }}
+                {%- elif trigger.to_state.entity_id is match "person." and trigger.to_state.state != 'home' -%} {{ nextion_colors.graydark }}
+                {%- elif trigger.to_state.entity_id is match "climate." and trigger.to_state.state != 'off' -%} {{ nextion_colors.white }}
+                {%- elif trigger.to_state.entity_id is match "climate." and trigger.to_state.state == 'off' -%} {{ nextion_colors.graydark }}
                 {%- endif -%}
               # ICON Font Color
               btn_icon_font: >-
@@ -8149,23 +8161,23 @@ action:
                 {%- elif trigger.entity_id == entity30 and ((trigger.to_state.state == 'on' or trigger.to_state.state == 'open') or (trigger.to_state.entity_id is match "button.") or (trigger.to_state.entity_id is match "input_button.") or (trigger.to_state.entity_id is match "scene.") or (trigger.to_state.entity_id is match "person." and trigger.to_state.state == 'home') or (trigger.to_state.entity_id is match "climate." and trigger.to_state.state != 'off') ) -%} {{ entity30_icon_color }}
                 {%- elif trigger.entity_id == entity31 and ((trigger.to_state.state == 'on' or trigger.to_state.state == 'open') or (trigger.to_state.entity_id is match "button.") or (trigger.to_state.entity_id is match "input_button.") or (trigger.to_state.entity_id is match "scene.") or (trigger.to_state.entity_id is match "person." and trigger.to_state.state == 'home') or (trigger.to_state.entity_id is match "climate." and trigger.to_state.state != 'off') ) -%} {{ entity31_icon_color }}
                 {%- elif trigger.entity_id == entity32 and ((trigger.to_state.state == 'on' or trigger.to_state.state == 'open') or (trigger.to_state.entity_id is match "button.") or (trigger.to_state.entity_id is match "input_button.") or (trigger.to_state.entity_id is match "scene.") or (trigger.to_state.entity_id is match "person." and trigger.to_state.state == 'home') or (trigger.to_state.entity_id is match "climate." and trigger.to_state.state != 'off') ) -%} {{ entity32_icon_color }}
-                {%- elif trigger.to_state.state == 'off' or trigger.to_state.state == 'closed' -%} {{ color_03 }}
-                {%- elif trigger.to_state.entity_id is match "person." and trigger.to_state.state != 'home' -%} {{ color_03 }}
-                {%- elif trigger.to_state.entity_id is match "climate." and trigger.to_state.state == 'off' -%} {{ color_03 }}
+                {%- elif trigger.to_state.state == 'off' or trigger.to_state.state == 'closed' -%} {{ nextion_colors.graylight }}
+                {%- elif trigger.to_state.entity_id is match "person." and trigger.to_state.state != 'home' -%} {{ nextion_colors.graylight }}
+                {%- elif trigger.to_state.entity_id is match "climate." and trigger.to_state.state == 'off' -%} {{ nextion_colors.graylight }}
                 {%- endif -%}
 
               # LABEL Font Color
               btn_txt_font: >-
-                {%- if trigger.to_state.entity_id is match "button." or trigger.to_state.entity_id is match "input_button." or trigger.to_state.entity_id is match "scene." -%} {{ color_02 }}
-                {%- elif trigger.to_state.state == 'on' or trigger.to_state.state == 'open' -%} {{ color_02 }}
-                {%- elif trigger.to_state.state == 'off' or trigger.to_state.state == 'closed' -%} {{ color_01 }}
-                {%- elif trigger.to_state.entity_id is match "person." and trigger.to_state.state == 'home' -%} {{ color_02 }}
-                {%- elif trigger.to_state.entity_id is match "person." and trigger.to_state.state != 'home' -%} {{ color_01 }}
-                {%- elif trigger.to_state.entity_id is match "climate." and trigger.to_state.state != 'off' -%} {{ color_02 }}
-                {%- elif trigger.to_state.entity_id is match "climate." and trigger.to_state.state == 'off' -%} {{ color_01 }}
+                {%- if trigger.to_state.entity_id is match "button." or trigger.to_state.entity_id is match "input_button." or trigger.to_state.entity_id is match "scene." -%} {{ nextion_colors.graydark }}
+                {%- elif trigger.to_state.state == 'on' or trigger.to_state.state == 'open' -%} {{ nextion_colors.graydark }}
+                {%- elif trigger.to_state.state == 'off' or trigger.to_state.state == 'closed' -%} {{ nextion_colors.white }}
+                {%- elif trigger.to_state.entity_id is match "person." and trigger.to_state.state == 'home' -%} {{ nextion_colors.graydark }}
+                {%- elif trigger.to_state.entity_id is match "person." and trigger.to_state.state != 'home' -%} {{ nextion_colors.white }}
+                {%- elif trigger.to_state.entity_id is match "climate." and trigger.to_state.state != 'off' -%} {{ nextion_colors.graydark }}
+                {%- elif trigger.to_state.entity_id is match "climate." and trigger.to_state.state == 'off' -%} {{ nextion_colors.white }}
                 {%- endif -%}
               # BRIGHTNESS Font Color
-              btn_bri_font: "{{ color_02 }}"
+              btn_bri_font: "{{ nextion_colors.graydark }}"
               # BRIGHTNESS Value
               btn_bri_txt: >-
                 {%- if trigger.to_state.entity_id is match "light." and trigger.to_state.state == 'on' and trigger.to_state.attributes.brightness is defined -%} {{ (trigger.to_state.attributes.brightness | int * 100 /255) | round(0) }}%
@@ -8252,8 +8264,8 @@ action:
                     {%- elif trigger.to_state.entity_id is match "input_button." -%} {{ button_off }}
                     {%- elif trigger.to_state.entity_id is match "scene." -%} {{ button_off }}
                     {%- endif -%}
-                  btn_bg: '{{ color_02 }}'
-                  btn_txt_font: '{{ color_01 }}'
+                  btn_bg: '{{ nextion_colors.graydark }}'
+                  btn_txt_font: '{{ nextion_colors.white }}'
 
               ##### Button PIC #####
               - service: "{{ command_printf }}"
@@ -8300,7 +8312,7 @@ action:
           #               {%- endif -%}
           #             lightsettings_icon_font_color: >-
           #               {%- if states(entity_long) == 'on' -%} {{ entity_long_icon_color }}
-          #               {%- else -%} {{ color_03 }}
+          #               {%- else -%} {{ nextion_colors.graylight }}
           #               {%- endif -%}
           #         - delay:
           #             milliseconds: "{{ delay_value }}"
@@ -8431,7 +8443,7 @@ action:
           #               {%- endif -%}
           #             coversettings_icon_font_color: >-
           #               {%- if states(entity_long) == 'open' -%} {{ entity_long_icon_color }}
-          #               {%- else -%} {{ color_03 }}
+          #               {%- else -%} {{ nextion_colors.graylight }}
           #               {%- endif -%}
           #         - delay:
           #             milliseconds: "{{ delay_value }}"
@@ -9615,7 +9627,7 @@ action:
               set_button04_icon_font: >-
                 {%- if is_state(notification_unread, 'on') and states(notification_text) |length > 0 -%} {{ home_button04_icon_color01 }}
                 {%- elif is_state(notification_unread, 'off') and states(notification_text) |length > 0 -%} {{ home_button04_icon_color02 }}
-                {%- else -%} {{ color_03 }}
+                {%- else -%} {{ nextion_colors.graylight }}
                 {%- endif -%}
           ##### SET ICON Font - Notify #####
           - delay:

--- a/nspanel_blueprint.yaml
+++ b/nspanel_blueprint.yaml
@@ -165,9 +165,33 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
     home_outdoor_temp_label_color:
       name: Outdoor Temperature Sensor - LABEL COLOR (Optional)
       description: '* *Page "HOME" - Label color which should be displayed*'
-      default: 65535 #White
+      default: white
       selector:
-        text: {}
+        select:
+          multiple: false
+          options:
+            - label: Black
+              value: black
+            - label: Blue
+              value: blue
+            - label: Brown
+              value: brown
+            - label: Gray
+              value: gray
+            - label: Gray - Dark
+              value: graydark
+            - label: Gray - Light
+              value: graylight
+            - label: Gray - Super light
+              value: graysuperlight
+            - label: Green
+              value: green
+            - label: Red
+              value: red
+            - label: White
+              value: white
+            - label: Yellow
+              value: yellow
     indoortemp:
       name: Indoor Temperature Sensor - ENTITY (Optional)
       description: '* *Page "HOME" - An indoor temperature sensor is not necessary. Leave the field empty if you want to use the temperature sensor of the NSPanel. Additionally a temperature correction for the NSPanel sensor is possible under HA Devices. So everyone can adjust the sensor exactly*'
@@ -185,15 +209,63 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
     home_indoor_temp_icon_color:
       name: Indoor Temperature Sensor - ICON COLOR (Optional)
       description: '* *Page "HOME" - Icon color which should be displayed*'
-      default: 65535 #White
+      default: white
       selector:
-        text: {}
+        select:
+          multiple: false
+          options:
+            - label: Black
+              value: black
+            - label: Blue
+              value: blue
+            - label: Brown
+              value: brown
+            - label: Gray
+              value: gray
+            - label: Gray - Dark
+              value: graydark
+            - label: Gray - Light
+              value: graylight
+            - label: Gray - Super light
+              value: graysuperlight
+            - label: Green
+              value: green
+            - label: Red
+              value: red
+            - label: White
+              value: white
+            - label: Yellow
+              value: yellow
     home_indoor_temp_label_color:
       name: Indoor Temperature Sensor - LABEL COLOR (Optional)
       description: '* *Page "HOME" - Label color which should be displayed*'
-      default: 65535 #White
+      default: white
       selector:
-        text: {}
+        select:
+          multiple: false
+          options:
+            - label: Black
+              value: black
+            - label: Blue
+              value: blue
+            - label: Brown
+              value: brown
+            - label: Gray
+              value: gray
+            - label: Gray - Dark
+              value: graydark
+            - label: Gray - Light
+              value: graylight
+            - label: Gray - Super light
+              value: graysuperlight
+            - label: Green
+              value: green
+            - label: Red
+              value: red
+            - label: White
+              value: white
+            - label: Yellow
+              value: yellow
 
     ##### PLACEHOLDER ######################################################################
     placeholder02:
@@ -224,15 +296,63 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
     home_value01_icon_color:
       name: Sensor 01 - ICON COLOR (Optional)
       description: '* *Page "HOME" - Icon color which should be displayed*'
-      default: 52857 #Grey super light
+      default: graysuperlight
       selector:
-        text: {}
+        select:
+          multiple: false
+          options:
+            - label: Black
+              value: black
+            - label: Blue
+              value: blue
+            - label: Brown
+              value: brown
+            - label: Gray
+              value: gray
+            - label: Gray - Dark
+              value: graydark
+            - label: Gray - Light
+              value: graylight
+            - label: Gray - Super light
+              value: graysuperlight
+            - label: Green
+              value: green
+            - label: Red
+              value: red
+            - label: White
+              value: white
+            - label: Yellow
+              value: yellow
     home_value01_label_color:
       name: Sensor 01 - LABEL COLOR (Optional)
       description: '* *Page "HOME" - Label color which should be displayed*'
-      default: 52857 #Grey super light
+      default: graysuperlight
       selector:
-        text: {}
+        select:
+          multiple: false
+          options:
+            - label: Black
+              value: black
+            - label: Blue
+              value: blue
+            - label: Brown
+              value: brown
+            - label: Gray
+              value: gray
+            - label: Gray - Dark
+              value: graydark
+            - label: Gray - Light
+              value: graylight
+            - label: Gray - Super light
+              value: graysuperlight
+            - label: Green
+              value: green
+            - label: Red
+              value: red
+            - label: White
+              value: white
+            - label: Yellow
+              value: yellow
     home_value02:
       name: Sensor 02 - ENTITY (Optional)
       description: '* *Page "HOME" - Entity which should be displayed*'
@@ -250,15 +370,63 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
     home_value02_icon_color:
       name: Sensor 02 - ICON COLOR (Optional)
       description: '* *Page "HOME" - Icon color which should be displayed*'
-      default: 52857 #Grey super light
+      default: graysuperlight
       selector:
-        text: {}
+        select:
+          multiple: false
+          options:
+            - label: Black
+              value: black
+            - label: Blue
+              value: blue
+            - label: Brown
+              value: brown
+            - label: Gray
+              value: gray
+            - label: Gray - Dark
+              value: graydark
+            - label: Gray - Light
+              value: graylight
+            - label: Gray - Super light
+              value: graysuperlight
+            - label: Green
+              value: green
+            - label: Red
+              value: red
+            - label: White
+              value: white
+            - label: Yellow
+              value: yellow
     home_value02_label_color:
       name: Sensor 02 - LABEL COLOR (Optional)
       description: '* *Page "HOME" - Label color which should be displayed*'
-      default: 52857 #Grey super light
+      default: graysuperlight
       selector:
-        text: {}
+        select:
+          multiple: false
+          options:
+            - label: Black
+              value: black
+            - label: Blue
+              value: blue
+            - label: Brown
+              value: brown
+            - label: Gray
+              value: gray
+            - label: Gray - Dark
+              value: graydark
+            - label: Gray - Light
+              value: graylight
+            - label: Gray - Super light
+              value: graysuperlight
+            - label: Green
+              value: green
+            - label: Red
+              value: red
+            - label: White
+              value: white
+            - label: Yellow
+              value: yellow
     home_value03:
       name: Sensor 03 - ENTITY (Optional)
       description: '* *Page "HOME" - Entity which should be displayed*'
@@ -276,15 +444,63 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
     home_value03_icon_color:
       name: Sensor 03 - ICON COLOR (Optional)
       description: '* *Page "HOME" - Icon color which should be displayed*'
-      default: 52857 #Grey super light
+      default: graysuperlight
       selector:
-        text: {}
+        select:
+          multiple: false
+          options:
+            - label: Black
+              value: black
+            - label: Blue
+              value: blue
+            - label: Brown
+              value: brown
+            - label: Gray
+              value: gray
+            - label: Gray - Dark
+              value: graydark
+            - label: Gray - Light
+              value: graylight
+            - label: Gray - Super light
+              value: graysuperlight
+            - label: Green
+              value: green
+            - label: Red
+              value: red
+            - label: White
+              value: white
+            - label: Yellow
+              value: yellow
     home_value03_label_color:
       name: Sensor 03 - LABEL COLOR (Optional)
       description: '* *Page "HOME" - Label color which should be displayed*'
-      default: 52857 #Grey super light
+      default: graysuperlight
       selector:
-        text: {}
+        select:
+          multiple: false
+          options:
+            - label: Black
+              value: black
+            - label: Blue
+              value: blue
+            - label: Brown
+              value: brown
+            - label: Gray
+              value: gray
+            - label: Gray - Dark
+              value: graydark
+            - label: Gray - Light
+              value: graylight
+            - label: Gray - Super light
+              value: graysuperlight
+            - label: Green
+              value: green
+            - label: Red
+              value: red
+            - label: White
+              value: white
+            - label: Yellow
+              value: yellow
 
     ##### PLACEHOLDER ######################################################################
     placeholder03:
@@ -318,9 +534,33 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
     chip01_icon_color:
       name: Chip 01 - ICON COLOR (Optional)
       description: '* *Page "HOME" - Icon color which should be displayed*'
-      default: 33808 #Grey light
+      default: graylight
       selector:
-        text: {}
+        select:
+          multiple: false
+          options:
+            - label: Black
+              value: black
+            - label: Blue
+              value: blue
+            - label: Brown
+              value: brown
+            - label: Gray
+              value: gray
+            - label: Gray - Dark
+              value: graydark
+            - label: Gray - Light
+              value: graylight
+            - label: Gray - Super light
+              value: graysuperlight
+            - label: Green
+              value: green
+            - label: Red
+              value: red
+            - label: White
+              value: white
+            - label: Yellow
+              value: yellow
     chip02:
       name: Chip 02 - ENTITY (Optional)
       description: '* *Page "HOME" - Entity which should be displayed (ONLY light | switch | binary_sensor | sensor | with state ON/OFF)*'
@@ -341,9 +581,33 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
     chip02_icon_color:
       name: Chip 02 - ICON COLOR (Optional)
       description: '* *Page "HOME" - Icon color which should be displayed*'
-      default: 33808 #Grey light
+      default: graylight
       selector:
-        text: {}
+        select:
+          multiple: false
+          options:
+            - label: Black
+              value: black
+            - label: Blue
+              value: blue
+            - label: Brown
+              value: brown
+            - label: Gray
+              value: gray
+            - label: Gray - Dark
+              value: graydark
+            - label: Gray - Light
+              value: graylight
+            - label: Gray - Super light
+              value: graysuperlight
+            - label: Green
+              value: green
+            - label: Red
+              value: red
+            - label: White
+              value: white
+            - label: Yellow
+              value: yellow
     chip03:
       name: Chip 03 - ENTITY (Optional)
       description: '* *Page "HOME" - Entity which should be displayed (ONLY light | switch | binary_sensor | sensor | with state ON/OFF)*'
@@ -364,9 +628,33 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
     chip03_icon_color:
       name: Chip 03 - ICON COLOR (Optional)
       description: '* *Page "HOME" - Icon color which should be displayed*'
-      default: 33808 #Grey light
+      default: graylight
       selector:
-        text: {}
+        select:
+          multiple: false
+          options:
+            - label: Black
+              value: black
+            - label: Blue
+              value: blue
+            - label: Brown
+              value: brown
+            - label: Gray
+              value: gray
+            - label: Gray - Dark
+              value: graydark
+            - label: Gray - Light
+              value: graylight
+            - label: Gray - Super light
+              value: graysuperlight
+            - label: Green
+              value: green
+            - label: Red
+              value: red
+            - label: White
+              value: white
+            - label: Yellow
+              value: yellow
     chip04:
       name: Chip 04 - ENTITY (Optional)
       description: '* *Page "HOME" - Entity which should be displayed (ONLY light | switch | binary_sensor | sensor | with state ON/OFF)*'
@@ -387,9 +675,33 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
     chip04_icon_color:
       name: Chip 04 - ICON COLOR (Optional)
       description: '* *Page "HOME" - Icon color which should be displayed*'
-      default: 33808 #Grey light
+      default: graylight
       selector:
-        text: {}
+        select:
+          multiple: false
+          options:
+            - label: Black
+              value: black
+            - label: Blue
+              value: blue
+            - label: Brown
+              value: brown
+            - label: Gray
+              value: gray
+            - label: Gray - Dark
+              value: graydark
+            - label: Gray - Light
+              value: graylight
+            - label: Gray - Super light
+              value: graysuperlight
+            - label: Green
+              value: green
+            - label: Red
+              value: red
+            - label: White
+              value: white
+            - label: Yellow
+              value: yellow
     chip05:
       name: Chip 05 - ENTITY (Optional)
       description: '* *Page "HOME" - Entity which should be displayed (ONLY light | switch | binary_sensor | sensor | with state ON/OFF)*'
@@ -410,9 +722,33 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
     chip05_icon_color:
       name: Chip 05 - ICON COLOR (Optional)
       description: '* *Page "HOME" - Icon color which should be displayed*'
-      default: 33808 #Grey light
+      default: graylight
       selector:
-        text: {}
+        select:
+          multiple: false
+          options:
+            - label: Black
+              value: black
+            - label: Blue
+              value: blue
+            - label: Brown
+              value: brown
+            - label: Gray
+              value: gray
+            - label: Gray - Dark
+              value: graydark
+            - label: Gray - Light
+              value: graylight
+            - label: Gray - Super light
+              value: graysuperlight
+            - label: Green
+              value: green
+            - label: Red
+              value: red
+            - label: White
+              value: white
+            - label: Yellow
+              value: yellow
     chip06:
       name: Chip 06 - ENTITY (Optional)
       description: '* *Page "HOME" - Entity which should be displayed (ONLY light | switch | binary_sensor | sensor | with state ON/OFF)*'
@@ -433,9 +769,33 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
     chip06_icon_color:
       name: Chip 06 - ICON COLOR (Optional)
       description: '* *Page "HOME" - Icon color which should be displayed*'
-      default: 33808 #Grey light
+      default: graylight
       selector:
-        text: {}
+        select:
+          multiple: false
+          options:
+            - label: Black
+              value: black
+            - label: Blue
+              value: blue
+            - label: Brown
+              value: brown
+            - label: Gray
+              value: gray
+            - label: Gray - Dark
+              value: graydark
+            - label: Gray - Light
+              value: graylight
+            - label: Gray - Super light
+              value: graysuperlight
+            - label: Green
+              value: green
+            - label: Red
+              value: red
+            - label: White
+              value: white
+            - label: Yellow
+              value: yellow
     chip07:
       name: Chip 07 - ENTITY (Optional)
       description: '* *Page "HOME" - Entity which should be displayed (ONLY light | switch | binary_sensor | sensor | with state ON/OFF)*'
@@ -456,9 +816,33 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
     chip07_icon_color:
       name: Chip 07 - ICON COLOR (Optional)
       description: '* *Page "HOME" - Icon color which should be displayed*'
-      default: 33808 #Grey light
+      default: graylight
       selector:
-        text: {}
+        select:
+          multiple: false
+          options:
+            - label: Black
+              value: black
+            - label: Blue
+              value: blue
+            - label: Brown
+              value: brown
+            - label: Gray
+              value: gray
+            - label: Gray - Dark
+              value: graydark
+            - label: Gray - Light
+              value: graylight
+            - label: Gray - Super light
+              value: graysuperlight
+            - label: Green
+              value: green
+            - label: Red
+              value: red
+            - label: White
+              value: white
+            - label: Yellow
+              value: yellow
 
     ##### PLACEHOLDER ######################################################################
     placeholder04:
@@ -536,9 +920,33 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
     home_button05_icon_color:
       name: QR Code - ICON COLOR (Optional)
       description: '* *Page "HOME" - Icon color which should be displayed (default color is set)*'
-      default: 52857 #Grey super light
+      default: graysuperlight
       selector:
-        text: {}
+        select:
+          multiple: false
+          options:
+            - label: Black
+              value: black
+            - label: Blue
+              value: blue
+            - label: Brown
+              value: brown
+            - label: Gray
+              value: gray
+            - label: Gray - Dark
+              value: graydark
+            - label: Gray - Light
+              value: graylight
+            - label: Gray - Super light
+              value: graysuperlight
+            - label: Green
+              value: green
+            - label: Red
+              value: red
+            - label: White
+              value: white
+            - label: Yellow
+              value: yellow
 
     ##### PLACEHOLDER ######################################################################
     placeholder06:
@@ -609,9 +1017,33 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
     left_button_color:
       name: Left hardware button - LABEL COLOR (Optional)
       description: '* *Page "HOME" - LABEL color which should be displayed*'
-      default: 52857 #Grey super light
+      default: graysuperlight
       selector:
-        text: {}
+        select:
+          multiple: false
+          options:
+            - label: Black
+              value: black
+            - label: Blue
+              value: blue
+            - label: Brown
+              value: brown
+            - label: Gray
+              value: gray
+            - label: Gray - Dark
+              value: graydark
+            - label: Gray - Light
+              value: graylight
+            - label: Gray - Super light
+              value: graysuperlight
+            - label: Green
+              value: green
+            - label: Red
+              value: red
+            - label: White
+              value: white
+            - label: Yellow
+              value: yellow
 
     relay_2_local_fallback:
       name: Activate relay 2 local fallback - TRUE/FALSE (Optional)
@@ -660,9 +1092,33 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
     right_button_color:
       name: Right hardware button - LABEL COLOR (Optional)
       description: '* *Page "HOME" - LABEL color which should be displayed*'
-      default: 52857 #Grey super light
+      default: graysuperlight
       selector:
-        text: {}
+        select:
+          multiple: false
+          options:
+            - label: Black
+              value: black
+            - label: Blue
+              value: blue
+            - label: Brown
+              value: brown
+            - label: Gray
+              value: gray
+            - label: Gray - Dark
+              value: graydark
+            - label: Gray - Light
+              value: graylight
+            - label: Gray - Super light
+              value: graysuperlight
+            - label: Green
+              value: green
+            - label: Red
+              value: red
+            - label: White
+              value: white
+            - label: Yellow
+              value: yellow
 
     ##### PLACEHOLDER ######################################################################
     placeholder07:
@@ -740,9 +1196,33 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
     entity01_icon_color:
       name: Button 01 - ICON COLOR (Optional)
       description: '* *Page "BUTTONPAGE01" - Icon color which should be displayed when button is on*'
-      default: 1055 #Blue
+      default: blue
       selector:
-        text: {}
+        select:
+          multiple: false
+          options:
+            - label: Black
+              value: black
+            - label: Blue
+              value: blue
+            - label: Brown
+              value: brown
+            - label: Gray
+              value: gray
+            - label: Gray - Dark
+              value: graydark
+            - label: Gray - Light
+              value: graylight
+            - label: Gray - Super light
+              value: graysuperlight
+            - label: Green
+              value: green
+            - label: Red
+              value: red
+            - label: White
+              value: white
+            - label: Yellow
+              value: yellow
     entity01_confirm:
       name: Confirm execution of the button press - TRUE/FALSE (Optional)
       default: false
@@ -784,9 +1264,33 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
     entity02_icon_color:
       name: Button 02 - ICON COLOR (Optional)
       description: '* *Page "BUTTONPAGE01" - Icon color which should be displayed when button is on*'
-      default: 1055 #Blue
+      default: blue
       selector:
-        text: {}
+        select:
+          multiple: false
+          options:
+            - label: Black
+              value: black
+            - label: Blue
+              value: blue
+            - label: Brown
+              value: brown
+            - label: Gray
+              value: gray
+            - label: Gray - Dark
+              value: graydark
+            - label: Gray - Light
+              value: graylight
+            - label: Gray - Super light
+              value: graysuperlight
+            - label: Green
+              value: green
+            - label: Red
+              value: red
+            - label: White
+              value: white
+            - label: Yellow
+              value: yellow
     entity02_confirm:
       name: Confirm execution of the button press - TRUE/FALSE (Optional)
       default: false
@@ -828,9 +1332,33 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
     entity03_icon_color:
       name: Button 03 - ICON COLOR (Optional)
       description: '* *Page "BUTTONPAGE01" - Icon color which should be displayed when button is on*'
-      default: 1055 #Blue
+      default: blue
       selector:
-        text: {}
+        select:
+          multiple: false
+          options:
+            - label: Black
+              value: black
+            - label: Blue
+              value: blue
+            - label: Brown
+              value: brown
+            - label: Gray
+              value: gray
+            - label: Gray - Dark
+              value: graydark
+            - label: Gray - Light
+              value: graylight
+            - label: Gray - Super light
+              value: graysuperlight
+            - label: Green
+              value: green
+            - label: Red
+              value: red
+            - label: White
+              value: white
+            - label: Yellow
+              value: yellow
     entity03_confirm:
       name: Confirm execution of the button press - TRUE/FALSE (Optional)
       default: false
@@ -916,9 +1444,33 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
     entity05_icon_color:
       name: Button 05 - ICON COLOR (Optional)
       description: '* *Page "BUTTONPAGE01" - Icon color which should be displayed when button is on*'
-      default: 1055 #Blue
+      default: blue
       selector:
-        text: {}
+        select:
+          multiple: false
+          options:
+            - label: Black
+              value: black
+            - label: Blue
+              value: blue
+            - label: Brown
+              value: brown
+            - label: Gray
+              value: gray
+            - label: Gray - Dark
+              value: graydark
+            - label: Gray - Light
+              value: graylight
+            - label: Gray - Super light
+              value: graysuperlight
+            - label: Green
+              value: green
+            - label: Red
+              value: red
+            - label: White
+              value: white
+            - label: Yellow
+              value: yellow
     entity05_confirm:
       name: Confirm execution of the button press - TRUE/FALSE (Optional)
       default: false
@@ -960,9 +1512,33 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
     entity06_icon_color:
       name: Button 06 - ICON COLOR (Optional)
       description: '* *Page "BUTTONPAGE01" - Icon color which should be displayed when button is on*'
-      default: 1055 #Blue
+      default: blue
       selector:
-        text: {}
+        select:
+          multiple: false
+          options:
+            - label: Black
+              value: black
+            - label: Blue
+              value: blue
+            - label: Brown
+              value: brown
+            - label: Gray
+              value: gray
+            - label: Gray - Dark
+              value: graydark
+            - label: Gray - Light
+              value: graylight
+            - label: Gray - Super light
+              value: graysuperlight
+            - label: Green
+              value: green
+            - label: Red
+              value: red
+            - label: White
+              value: white
+            - label: Yellow
+              value: yellow
     entity06_confirm:
       name: Confirm execution of the button press - TRUE/FALSE (Optional)
       default: false
@@ -1004,9 +1580,33 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
     entity07_icon_color:
       name: Button 07 - ICON COLOR (Optional)
       description: '* *Page "BUTTONPAGE01" - Icon color which should be displayed when button is on*'
-      default: 1055 #Blue
+      default: blue
       selector:
-        text: {}
+        select:
+          multiple: false
+          options:
+            - label: Black
+              value: black
+            - label: Blue
+              value: blue
+            - label: Brown
+              value: brown
+            - label: Gray
+              value: gray
+            - label: Gray - Dark
+              value: graydark
+            - label: Gray - Light
+              value: graylight
+            - label: Gray - Super light
+              value: graysuperlight
+            - label: Green
+              value: green
+            - label: Red
+              value: red
+            - label: White
+              value: white
+            - label: Yellow
+              value: yellow
     entity07_confirm:
       name: Confirm execution of the button press - TRUE/FALSE (Optional)
       default: false
@@ -1048,9 +1648,33 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
     entity08_icon_color:
       name: Button 08 - ICON COLOR (Optional)
       description: '* *Page "BUTTONPAGE01" - Icon color which should be displayed when button is on*'
-      default: 1055 #Blue
+      default: blue
       selector:
-        text: {}
+        select:
+          multiple: false
+          options:
+            - label: Black
+              value: black
+            - label: Blue
+              value: blue
+            - label: Brown
+              value: brown
+            - label: Gray
+              value: gray
+            - label: Gray - Dark
+              value: graydark
+            - label: Gray - Light
+              value: graylight
+            - label: Gray - Super light
+              value: graysuperlight
+            - label: Green
+              value: green
+            - label: Red
+              value: red
+            - label: White
+              value: white
+            - label: Yellow
+              value: yellow
     entity08_confirm:
       name: Confirm execution of the button press - TRUE/FALSE (Optional)
       default: false
@@ -1102,9 +1726,33 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
     entity09_icon_color:
       name: Button 09 - ICON COLOR (Optional)
       description: '* *Page "BUTTONPAGE02" - Icon color which should be displayed when button is on*'
-      default: 1055 #Blue
+      default: blue
       selector:
-        text: {}
+        select:
+          multiple: false
+          options:
+            - label: Black
+              value: black
+            - label: Blue
+              value: blue
+            - label: Brown
+              value: brown
+            - label: Gray
+              value: gray
+            - label: Gray - Dark
+              value: graydark
+            - label: Gray - Light
+              value: graylight
+            - label: Gray - Super light
+              value: graysuperlight
+            - label: Green
+              value: green
+            - label: Red
+              value: red
+            - label: White
+              value: white
+            - label: Yellow
+              value: yellow
     entity09_confirm:
       name: Confirm execution of the button press - TRUE/FALSE (Optional)
       default: false
@@ -1146,9 +1794,33 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
     entity10_icon_color:
       name: Button 10 - ICON COLOR (Optional)
       description: '* *Page "BUTTONPAGE02" - Icon color which should be displayed when button is on*'
-      default: 1055 #Blue
+      default: blue
       selector:
-        text: {}
+        select:
+          multiple: false
+          options:
+            - label: Black
+              value: black
+            - label: Blue
+              value: blue
+            - label: Brown
+              value: brown
+            - label: Gray
+              value: gray
+            - label: Gray - Dark
+              value: graydark
+            - label: Gray - Light
+              value: graylight
+            - label: Gray - Super light
+              value: graysuperlight
+            - label: Green
+              value: green
+            - label: Red
+              value: red
+            - label: White
+              value: white
+            - label: Yellow
+              value: yellow
     entity10_confirm:
       name: Confirm execution of the button press - TRUE/FALSE (Optional)
       default: false
@@ -1190,9 +1862,33 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
     entity11_icon_color:
       name: Button 11 - ICON COLOR (Optional)
       description: '* *Page "BUTTONPAGE02" - Icon color which should be displayed when button is on*'
-      default: 1055 #Blue
+      default: blue
       selector:
-        text: {}
+        select:
+          multiple: false
+          options:
+            - label: Black
+              value: black
+            - label: Blue
+              value: blue
+            - label: Brown
+              value: brown
+            - label: Gray
+              value: gray
+            - label: Gray - Dark
+              value: graydark
+            - label: Gray - Light
+              value: graylight
+            - label: Gray - Super light
+              value: graysuperlight
+            - label: Green
+              value: green
+            - label: Red
+              value: red
+            - label: White
+              value: white
+            - label: Yellow
+              value: yellow
     entity11_confirm:
       name: Confirm execution of the button press - TRUE/FALSE (Optional)
       default: false
@@ -1234,9 +1930,33 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
     entity12_icon_color:
       name: Button 12 - ICON COLOR (Optional)
       description: '* *Page "BUTTONPAGE02" - Icon color which should be displayed when button is on*'
-      default: 1055 #Blue
+      default: blue
       selector:
-        text: {}
+        select:
+          multiple: false
+          options:
+            - label: Black
+              value: black
+            - label: Blue
+              value: blue
+            - label: Brown
+              value: brown
+            - label: Gray
+              value: gray
+            - label: Gray - Dark
+              value: graydark
+            - label: Gray - Light
+              value: graylight
+            - label: Gray - Super light
+              value: graysuperlight
+            - label: Green
+              value: green
+            - label: Red
+              value: red
+            - label: White
+              value: white
+            - label: Yellow
+              value: yellow
     entity12_confirm:
       name: Confirm execution of the button press - TRUE/FALSE (Optional)
       default: false
@@ -1278,9 +1998,33 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
     entity13_icon_color:
       name: Button 13 - ICON COLOR (Optional)
       description: '* *Page "BUTTONPAGE02" - Icon color which should be displayed when button is on*'
-      default: 1055 #Blue
+      default: blue
       selector:
-        text: {}
+        select:
+          multiple: false
+          options:
+            - label: Black
+              value: black
+            - label: Blue
+              value: blue
+            - label: Brown
+              value: brown
+            - label: Gray
+              value: gray
+            - label: Gray - Dark
+              value: graydark
+            - label: Gray - Light
+              value: graylight
+            - label: Gray - Super light
+              value: graysuperlight
+            - label: Green
+              value: green
+            - label: Red
+              value: red
+            - label: White
+              value: white
+            - label: Yellow
+              value: yellow
     entity13_confirm:
       name: Confirm execution of the button press - TRUE/FALSE (Optional)
       default: false
@@ -1322,9 +2066,33 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
     entity14_icon_color:
       name: Button 14 - ICON COLOR (Optional)
       description: '* *Page "BUTTONPAGE02" - Icon color which should be displayed when button is on*'
-      default: 1055 #Blue
+      default: blue
       selector:
-        text: {}
+        select:
+          multiple: false
+          options:
+            - label: Black
+              value: black
+            - label: Blue
+              value: blue
+            - label: Brown
+              value: brown
+            - label: Gray
+              value: gray
+            - label: Gray - Dark
+              value: graydark
+            - label: Gray - Light
+              value: graylight
+            - label: Gray - Super light
+              value: graysuperlight
+            - label: Green
+              value: green
+            - label: Red
+              value: red
+            - label: White
+              value: white
+            - label: Yellow
+              value: yellow
     entity14_confirm:
       name: Confirm execution of the button press - TRUE/FALSE (Optional)
       default: false
@@ -1366,9 +2134,33 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
     entity15_icon_color:
       name: Button 15 - ICON COLOR (Optional)
       description: '* *Page "BUTTONPAGE02" - Icon color which should be displayed when button is on*'
-      default: 1055 #Blue
+      default: blue
       selector:
-        text: {}
+        select:
+          multiple: false
+          options:
+            - label: Black
+              value: black
+            - label: Blue
+              value: blue
+            - label: Brown
+              value: brown
+            - label: Gray
+              value: gray
+            - label: Gray - Dark
+              value: graydark
+            - label: Gray - Light
+              value: graylight
+            - label: Gray - Super light
+              value: graysuperlight
+            - label: Green
+              value: green
+            - label: Red
+              value: red
+            - label: White
+              value: white
+            - label: Yellow
+              value: yellow
     entity15_confirm:
       name: Confirm execution of the button press - TRUE/FALSE (Optional)
       default: false
@@ -1410,9 +2202,33 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
     entity16_icon_color:
       name: Button 16 - ICON COLOR (Optional)
       description: '* *Page "BUTTONPAGE02" - Icon color which should be displayed when button is on*'
-      default: 1055 #Blue
+      default: blue
       selector:
-        text: {}
+        select:
+          multiple: false
+          options:
+            - label: Black
+              value: black
+            - label: Blue
+              value: blue
+            - label: Brown
+              value: brown
+            - label: Gray
+              value: gray
+            - label: Gray - Dark
+              value: graydark
+            - label: Gray - Light
+              value: graylight
+            - label: Gray - Super light
+              value: graysuperlight
+            - label: Green
+              value: green
+            - label: Red
+              value: red
+            - label: White
+              value: white
+            - label: Yellow
+              value: yellow
     entity16_confirm:
       name: Confirm execution of the button press - TRUE/FALSE (Optional)
       default: false
@@ -1464,9 +2280,33 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
     entity17_icon_color:
       name: Button 17 - ICON COLOR (Optional)
       description: '* *Page "BUTTONPAGE03" - Icon color which should be displayed when button is on*'
-      default: 1055 #Blue
+      default: blue
       selector:
-        text: {}
+        select:
+          multiple: false
+          options:
+            - label: Black
+              value: black
+            - label: Blue
+              value: blue
+            - label: Brown
+              value: brown
+            - label: Gray
+              value: gray
+            - label: Gray - Dark
+              value: graydark
+            - label: Gray - Light
+              value: graylight
+            - label: Gray - Super light
+              value: graysuperlight
+            - label: Green
+              value: green
+            - label: Red
+              value: red
+            - label: White
+              value: white
+            - label: Yellow
+              value: yellow
     entity17_confirm:
       name: Confirm execution of the button press - TRUE/FALSE (Optional)
       default: false
@@ -1508,9 +2348,33 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
     entity18_icon_color:
       name: Button 18 - ICON COLOR (Optional)
       description: '* *Page "BUTTONPAGE03" - Icon color which should be displayed when button is on*'
-      default: 1055 #Blue
+      default: blue
       selector:
-        text: {}
+        select:
+          multiple: false
+          options:
+            - label: Black
+              value: black
+            - label: Blue
+              value: blue
+            - label: Brown
+              value: brown
+            - label: Gray
+              value: gray
+            - label: Gray - Dark
+              value: graydark
+            - label: Gray - Light
+              value: graylight
+            - label: Gray - Super light
+              value: graysuperlight
+            - label: Green
+              value: green
+            - label: Red
+              value: red
+            - label: White
+              value: white
+            - label: Yellow
+              value: yellow
     entity18_confirm:
       name: Confirm execution of the button press - TRUE/FALSE (Optional)
       default: false
@@ -1552,9 +2416,33 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
     entity19_icon_color:
       name: Button 19 - ICON COLOR (Optional)
       description: '* *Page "BUTTONPAGE03" - Icon color which should be displayed when button is on*'
-      default: 1055 #Blue
+      default: blue
       selector:
-        text: {}
+        select:
+          multiple: false
+          options:
+            - label: Black
+              value: black
+            - label: Blue
+              value: blue
+            - label: Brown
+              value: brown
+            - label: Gray
+              value: gray
+            - label: Gray - Dark
+              value: graydark
+            - label: Gray - Light
+              value: graylight
+            - label: Gray - Super light
+              value: graysuperlight
+            - label: Green
+              value: green
+            - label: Red
+              value: red
+            - label: White
+              value: white
+            - label: Yellow
+              value: yellow
     entity19_confirm:
       name: Confirm execution of the button press - TRUE/FALSE (Optional)
       default: false
@@ -1596,9 +2484,33 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
     entity20_icon_color:
       name: Button 20 - ICON COLOR (Optional)
       description: '* *Page "BUTTONPAGE03" - Icon color which should be displayed when button is on*'
-      default: 1055 #Blue
+      default: blue
       selector:
-        text: {}
+        select:
+          multiple: false
+          options:
+            - label: Black
+              value: black
+            - label: Blue
+              value: blue
+            - label: Brown
+              value: brown
+            - label: Gray
+              value: gray
+            - label: Gray - Dark
+              value: graydark
+            - label: Gray - Light
+              value: graylight
+            - label: Gray - Super light
+              value: graysuperlight
+            - label: Green
+              value: green
+            - label: Red
+              value: red
+            - label: White
+              value: white
+            - label: Yellow
+              value: yellow
     entity20_confirm:
       name: Confirm execution of the button press - TRUE/FALSE (Optional)
       default: false
@@ -1640,9 +2552,33 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
     entity21_icon_color:
       name: Button 21 - ICON COLOR (Optional)
       description: '* *Page "BUTTONPAGE03" - Icon color which should be displayed when button is on*'
-      default: 1055 #Blue
+      default: blue
       selector:
-        text: {}
+        select:
+          multiple: false
+          options:
+            - label: Black
+              value: black
+            - label: Blue
+              value: blue
+            - label: Brown
+              value: brown
+            - label: Gray
+              value: gray
+            - label: Gray - Dark
+              value: graydark
+            - label: Gray - Light
+              value: graylight
+            - label: Gray - Super light
+              value: graysuperlight
+            - label: Green
+              value: green
+            - label: Red
+              value: red
+            - label: White
+              value: white
+            - label: Yellow
+              value: yellow
     entity21_confirm:
       name: Confirm execution of the button press - TRUE/FALSE (Optional)
       default: false
@@ -1684,9 +2620,33 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
     entity22_icon_color:
       name: Button 22 - ICON COLOR (Optional)
       description: '* *Page "BUTTONPAGE03" - Icon color which should be displayed when button is on*'
-      default: 1055 #Blue
+      default: blue
       selector:
-        text: {}
+        select:
+          multiple: false
+          options:
+            - label: Black
+              value: black
+            - label: Blue
+              value: blue
+            - label: Brown
+              value: brown
+            - label: Gray
+              value: gray
+            - label: Gray - Dark
+              value: graydark
+            - label: Gray - Light
+              value: graylight
+            - label: Gray - Super light
+              value: graysuperlight
+            - label: Green
+              value: green
+            - label: Red
+              value: red
+            - label: White
+              value: white
+            - label: Yellow
+              value: yellow
     entity22_confirm:
       name: Confirm execution of the button press - TRUE/FALSE (Optional)
       default: false
@@ -1728,9 +2688,33 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
     entity23_icon_color:
       name: Button 23 - ICON COLOR (Optional)
       description: '* *Page "BUTTONPAGE03" - Icon color which should be displayed when button is on*'
-      default: 1055 #Blue
+      default: blue
       selector:
-        text: {}
+        select:
+          multiple: false
+          options:
+            - label: Black
+              value: black
+            - label: Blue
+              value: blue
+            - label: Brown
+              value: brown
+            - label: Gray
+              value: gray
+            - label: Gray - Dark
+              value: graydark
+            - label: Gray - Light
+              value: graylight
+            - label: Gray - Super light
+              value: graysuperlight
+            - label: Green
+              value: green
+            - label: Red
+              value: red
+            - label: White
+              value: white
+            - label: Yellow
+              value: yellow
     entity23_confirm:
       name: Confirm execution of the button press - TRUE/FALSE (Optional)
       default: false
@@ -1772,9 +2756,33 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
     entity24_icon_color:
       name: Button 24 - ICON COLOR (Optional)
       description: '* *Page "BUTTONPAGE03" - Icon color which should be displayed when button is on*'
-      default: 1055 #Blue
+      default: blue
       selector:
-        text: {}
+        select:
+          multiple: false
+          options:
+            - label: Black
+              value: black
+            - label: Blue
+              value: blue
+            - label: Brown
+              value: brown
+            - label: Gray
+              value: gray
+            - label: Gray - Dark
+              value: graydark
+            - label: Gray - Light
+              value: graylight
+            - label: Gray - Super light
+              value: graysuperlight
+            - label: Green
+              value: green
+            - label: Red
+              value: red
+            - label: White
+              value: white
+            - label: Yellow
+              value: yellow
     entity24_confirm:
       name: Confirm execution of the button press - TRUE/FALSE (Optional)
       default: false
@@ -1826,9 +2834,33 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
     entity25_icon_color:
       name: Button 25 - ICON COLOR (Optional)
       description: '* *Page "BUTTONPAGE04" - Icon color which should be displayed when button is on*'
-      default: 1055 #Blue
+      default: blue
       selector:
-        text: {}
+        select:
+          multiple: false
+          options:
+            - label: Black
+              value: black
+            - label: Blue
+              value: blue
+            - label: Brown
+              value: brown
+            - label: Gray
+              value: gray
+            - label: Gray - Dark
+              value: graydark
+            - label: Gray - Light
+              value: graylight
+            - label: Gray - Super light
+              value: graysuperlight
+            - label: Green
+              value: green
+            - label: Red
+              value: red
+            - label: White
+              value: white
+            - label: Yellow
+              value: yellow
     entity25_confirm:
       name: Confirm execution of the button press - TRUE/FALSE (Optional)
       default: false
@@ -1870,9 +2902,33 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
     entity26_icon_color:
       name: Button 26 - ICON COLOR (Optional)
       description: '* *Page "BUTTONPAGE04" - Icon color which should be displayed when button is on*'
-      default: 1055 #Blue
+      default: blue
       selector:
-        text: {}
+        select:
+          multiple: false
+          options:
+            - label: Black
+              value: black
+            - label: Blue
+              value: blue
+            - label: Brown
+              value: brown
+            - label: Gray
+              value: gray
+            - label: Gray - Dark
+              value: graydark
+            - label: Gray - Light
+              value: graylight
+            - label: Gray - Super light
+              value: graysuperlight
+            - label: Green
+              value: green
+            - label: Red
+              value: red
+            - label: White
+              value: white
+            - label: Yellow
+              value: yellow
     entity26_confirm:
       name: Confirm execution of the button press - TRUE/FALSE (Optional)
       default: false
@@ -1914,9 +2970,33 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
     entity27_icon_color:
       name: Button 27 - ICON COLOR (Optional)
       description: '* *Page "BUTTONPAGE04" - Icon color which should be displayed when button is on*'
-      default: 1055 #Blue
+      default: blue
       selector:
-        text: {}
+        select:
+          multiple: false
+          options:
+            - label: Black
+              value: black
+            - label: Blue
+              value: blue
+            - label: Brown
+              value: brown
+            - label: Gray
+              value: gray
+            - label: Gray - Dark
+              value: graydark
+            - label: Gray - Light
+              value: graylight
+            - label: Gray - Super light
+              value: graysuperlight
+            - label: Green
+              value: green
+            - label: Red
+              value: red
+            - label: White
+              value: white
+            - label: Yellow
+              value: yellow
     entity27_confirm:
       name: Confirm execution of the button press - TRUE/FALSE (Optional)
       default: false
@@ -1958,9 +3038,33 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
     entity28_icon_color:
       name: Button 28 - ICON COLOR (Optional)
       description: '* *Page "BUTTONPAGE04" - Icon color which should be displayed when button is on*'
-      default: 1055 #Blue
+      default: blue
       selector:
-        text: {}
+        select:
+          multiple: false
+          options:
+            - label: Black
+              value: black
+            - label: Blue
+              value: blue
+            - label: Brown
+              value: brown
+            - label: Gray
+              value: gray
+            - label: Gray - Dark
+              value: graydark
+            - label: Gray - Light
+              value: graylight
+            - label: Gray - Super light
+              value: graysuperlight
+            - label: Green
+              value: green
+            - label: Red
+              value: red
+            - label: White
+              value: white
+            - label: Yellow
+              value: yellow
     entity28_confirm:
       name: Confirm execution of the button press - TRUE/FALSE (Optional)
       default: false
@@ -2002,9 +3106,33 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
     entity29_icon_color:
       name: Button 29 - ICON COLOR (Optional)
       description: '* *Page "BUTTONPAGE04" - Icon color which should be displayed when button is on*'
-      default: 1055 #Blue
+      default: blue
       selector:
-        text: {}
+        select:
+          multiple: false
+          options:
+            - label: Black
+              value: black
+            - label: Blue
+              value: blue
+            - label: Brown
+              value: brown
+            - label: Gray
+              value: gray
+            - label: Gray - Dark
+              value: graydark
+            - label: Gray - Light
+              value: graylight
+            - label: Gray - Super light
+              value: graysuperlight
+            - label: Green
+              value: green
+            - label: Red
+              value: red
+            - label: White
+              value: white
+            - label: Yellow
+              value: yellow
     entity29_confirm:
       name: Confirm execution of the button press - TRUE/FALSE (Optional)
       default: false
@@ -2046,9 +3174,33 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
     entity30_icon_color:
       name: Button 30 - ICON COLOR (Optional)
       description: '* *Page "BUTTONPAGE04" - Icon color which should be displayed when button is on*'
-      default: 1055 #Blue
+      default: blue
       selector:
-        text: {}
+        select:
+          multiple: false
+          options:
+            - label: Black
+              value: black
+            - label: Blue
+              value: blue
+            - label: Brown
+              value: brown
+            - label: Gray
+              value: gray
+            - label: Gray - Dark
+              value: graydark
+            - label: Gray - Light
+              value: graylight
+            - label: Gray - Super light
+              value: graysuperlight
+            - label: Green
+              value: green
+            - label: Red
+              value: red
+            - label: White
+              value: white
+            - label: Yellow
+              value: yellow
     entity30_confirm:
       name: Confirm execution of the button press - TRUE/FALSE (Optional)
       default: false
@@ -2090,9 +3242,33 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
     entity31_icon_color:
       name: Button 31 - ICON COLOR (Optional)
       description: '* *Page "BUTTONPAGE04" - Icon color which should be displayed when button is on*'
-      default: 1055 #Blue #Blue
+      default: blue
       selector:
-        text: {}
+        select:
+          multiple: false
+          options:
+            - label: Black
+              value: black
+            - label: Blue
+              value: blue
+            - label: Brown
+              value: brown
+            - label: Gray
+              value: gray
+            - label: Gray - Dark
+              value: graydark
+            - label: Gray - Light
+              value: graylight
+            - label: Gray - Super light
+              value: graysuperlight
+            - label: Green
+              value: green
+            - label: Red
+              value: red
+            - label: White
+              value: white
+            - label: Yellow
+              value: yellow
     entity31_confirm:
       name: Confirm execution of the button press - TRUE/FALSE (Optional)
       default: false
@@ -2134,9 +3310,33 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
     entity32_icon_color:
       name: Button 32 - ICON COLOR (Optional)
       description: '* *Page "BUTTONPAGE04" - Icon color which should be displayed when button is on*'
-      default: 1055 #Blue
+      default: blue
       selector:
-        text: {}
+        select:
+          multiple: false
+          options:
+            - label: Black
+              value: black
+            - label: Blue
+              value: blue
+            - label: Brown
+              value: brown
+            - label: Gray
+              value: gray
+            - label: Gray - Dark
+              value: graydark
+            - label: Gray - Light
+              value: graylight
+            - label: Gray - Super light
+              value: graysuperlight
+            - label: Green
+              value: green
+            - label: Red
+              value: red
+            - label: White
+              value: white
+            - label: Yellow
+              value: yellow
     entity32_confirm:
       name: Confirm execution of the button press - TRUE/FALSE (Optional)
       default: false
@@ -2171,9 +3371,33 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
     home_button06_icon_color:
       name: Entity page - ICON COLOR (Optional)
       description: '* *Page "HOME" - Icon color which should be displayed (default color is set)*'
-      default: 52857 #Grey super light
+      default: graysuperlight
       selector:
-        text: {}
+        select:
+          multiple: false
+          options:
+            - label: Black
+              value: black
+            - label: Blue
+              value: blue
+            - label: Brown
+              value: brown
+            - label: Gray
+              value: gray
+            - label: Gray - Dark
+              value: graydark
+            - label: Gray - Light
+              value: graylight
+            - label: Gray - Super light
+              value: graysuperlight
+            - label: Green
+              value: green
+            - label: Red
+              value: red
+            - label: White
+              value: white
+            - label: Yellow
+              value: yellow
     ##### ENTITY Page Labels #####
     ##### PLACEHOLDER ######################################################################
     placeholder12:
@@ -2839,15 +4063,63 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
     home_button04_icon_color01:
       name: Notification read - ICON COLOR (Optional)
       description: '* *Page "HOME" - Icon color which should be displayed (default color is set)*'
-      default: 52857  #Grey super light
+      default: graysuperlight
       selector:
-        text: {}
+        select:
+          multiple: false
+          options:
+            - label: Black
+              value: black
+            - label: Blue
+              value: blue
+            - label: Brown
+              value: brown
+            - label: Gray
+              value: gray
+            - label: Gray - Dark
+              value: graydark
+            - label: Gray - Light
+              value: graylight
+            - label: Gray - Super light
+              value: graysuperlight
+            - label: Green
+              value: green
+            - label: Red
+              value: red
+            - label: White
+              value: white
+            - label: Yellow
+              value: yellow
     home_button04_icon_color02:
       name: Notification unread - ICON COLOR (Optional)
       description: '* *Page "HOME" - Icon color which should be displayed (default color is set)*'
-      default: 63488 #Red
+      default: red
       selector:
-        text: {}
+        select:
+          multiple: false
+          options:
+            - label: Black
+              value: black
+            - label: Blue
+              value: blue
+            - label: Brown
+              value: brown
+            - label: Gray
+              value: gray
+            - label: Gray - Dark
+              value: graydark
+            - label: Gray - Light
+              value: graylight
+            - label: Gray - Super light
+              value: graysuperlight
+            - label: Green
+              value: green
+            - label: Red
+              value: red
+            - label: White
+              value: white
+            - label: Yellow
+              value: yellow
     relay01_icon:
       name: Relay 01 - ICON (Optional)
       description: '* *Page "HOME" - Icon which should be displayed (Default #E3A5) *'
@@ -2857,9 +4129,33 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
     relay01_icon_color:
       name: Relay 01 - ICON COLOR (Optional)
       description: '* *Page "HOME" - Icon color which should be displayed (default color is set)*'
-      default: 33808 #Grey light
+      default: graylight
       selector:
-        text: {}
+        select:
+          multiple: false
+          options:
+            - label: Black
+              value: black
+            - label: Blue
+              value: blue
+            - label: Brown
+              value: brown
+            - label: Gray
+              value: gray
+            - label: Gray - Dark
+              value: graydark
+            - label: Gray - Light
+              value: graylight
+            - label: Gray - Super light
+              value: graysuperlight
+            - label: Green
+              value: green
+            - label: Red
+              value: red
+            - label: White
+              value: white
+            - label: Yellow
+              value: yellow
     relay02_icon:
       name: Relay 02 - ICON (Optional)
       description: '* *Page "HOME" - Icon which should be displayed (Default #E3A8) *'
@@ -2869,9 +4165,33 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
     relay02_icon_color:
       name: Relay - ICON COLOR (Optional)
       description: '* *Page "HOME" - Icon color which should be displayed (default color is set)*'
-      default: 33808 #Grey light
+      default: graylight
       selector:
-        text: {}
+        select:
+          multiple: false
+          options:
+            - label: Black
+              value: black
+            - label: Blue
+              value: blue
+            - label: Brown
+              value: brown
+            - label: Gray
+              value: gray
+            - label: Gray - Dark
+              value: graydark
+            - label: Gray - Light
+              value: graylight
+            - label: Gray - Super light
+              value: graysuperlight
+            - label: Green
+              value: green
+            - label: Red
+              value: red
+            - label: White
+              value: white
+            - label: Yellow
+              value: yellow
     thermostat_icon:
       name: Thermostat - ICON (Optional)
       description: '* *Page "HOME" - Icon which should be displayed (Default #E50E) *'
@@ -2887,21 +4207,93 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
     thermostat_icon_color:
       name: Thermostat / Heat - ICON COLOR (Optional)
       description: '* *Page "HOME" - Icon color which should be displayed (default color is set)*'
-      default: 33808 #Grey light
+      default: graylight
       selector:
-        text: {}
+        select:
+          multiple: false
+          options:
+            - label: Black
+              value: black
+            - label: Blue
+              value: blue
+            - label: Brown
+              value: brown
+            - label: Gray
+              value: gray
+            - label: Gray - Dark
+              value: graydark
+            - label: Gray - Light
+              value: graylight
+            - label: Gray - Super light
+              value: graysuperlight
+            - label: Green
+              value: green
+            - label: Red
+              value: red
+            - label: White
+              value: white
+            - label: Yellow
+              value: yellow
     time_label_color:
       name: Time - LABEL COLOR (Optional)
       description: '* *Page "HOME" - Label color which should be displayed (default color is set)*'
-      default: 65535 #White
+      default: white
       selector:
-        text: {}
+        select:
+          multiple: false
+          options:
+            - label: Black
+              value: black
+            - label: Blue
+              value: blue
+            - label: Brown
+              value: brown
+            - label: Gray
+              value: gray
+            - label: Gray - Dark
+              value: graydark
+            - label: Gray - Light
+              value: graylight
+            - label: Gray - Super light
+              value: graysuperlight
+            - label: Green
+              value: green
+            - label: Red
+              value: red
+            - label: White
+              value: white
+            - label: Yellow
+              value: yellow
     date_label_color:
       name: Date - LABEL COLOR (Optional)
       description: '* *Page "HOME" - Label color which should be displayed (default color is set)*'
-      default: 65535 #White
+      default: white
       selector:
-        text: {}
+        select:
+          multiple: false
+          options:
+            - label: Black
+              value: black
+            - label: Blue
+              value: blue
+            - label: Brown
+              value: brown
+            - label: Gray
+              value: gray
+            - label: Gray - Dark
+              value: graydark
+            - label: Gray - Light
+              value: graylight
+            - label: Gray - Super light
+              value: graysuperlight
+            - label: Green
+              value: green
+            - label: Red
+              value: red
+            - label: White
+              value: white
+            - label: Yellow
+              value: yellow
 
 ###### Muss noch Raus ###############################################################################################################################################################################
     hotwatertemp:
@@ -4687,7 +6079,7 @@ action:
                   - service: "{{ command_font_color }}"
                     data:
                       component: home.date
-                      message: "{{ date_label_color }}"
+                      message: "{{ nextion_colors[date_label_color] | int(65535) }}"
                   ### DATE Font ###
                   - delay:
                       milliseconds: "{{ delay_value }}"
@@ -4703,7 +6095,7 @@ action:
                   - service: "{{ command_font_color }}"
                     data:
                       component: home.time
-                      message: "{{ time_label_color }}"
+                      message: "{{ nextion_colors[time_label_color] | int(65535) }}"
                   ### TIME Font ###
                   - delay:
                       milliseconds: "{{ delay_value }}"
@@ -4725,7 +6117,7 @@ action:
                   - service: "{{ command_font_color }}"
                     data:
                       component: home.outdoor_temp
-                      message: "{{ home_outdoor_temp_label_color }}"
+                      message: "{{ nextion_colors[home_outdoor_temp_label_color] | int(65535) }}"
                   ### LABEL Outdoor Temp Font ###
                   - delay:
                       milliseconds: "{{ delay_value }}"
@@ -4746,7 +6138,7 @@ action:
                   - service: "{{ command_font_color }}"
                     data:
                       component: home.indoortempicon
-                      message: "{{ home_indoor_temp_icon_color }}"
+                      message: "{{ nextion_colors[home_indoor_temp_icon_color] | int(65535) }}"
                   ### ICON Indoor Temp Font ###
                   - delay:
                       milliseconds: "{{ delay_value }}"
@@ -4760,7 +6152,7 @@ action:
                   - service: "{{ command_font_color }}"
                     data:
                       component: home.current_temp
-                      message: "{{ home_indoor_temp_label_color }}"
+                      message: "{{ nextion_colors[home_indoor_temp_label_color] | int(65535) }}"
                   ### LABEL Indoor Temp Font ###
                   - delay:
                       milliseconds: "{{ delay_value }}"
@@ -4809,7 +6201,7 @@ action:
                       - service: "{{ command_font_color }}"
                         data:
                           component: home.left_bt_text
-                          message: "{{ left_button_color }}"
+                          message: "{{ nextion_colors[left_button_color] | int(65535) }}"
                       ### LABEL Font ###
                       - delay:
                           milliseconds: "{{ delay_value }}"
@@ -4846,7 +6238,7 @@ action:
                       - service: "{{ command_font_color }}"
                         data:
                           component: home.right_bt_text
-                          message: "{{ right_button_color }}"
+                          message: "{{ nextion_colors[right_button_color] | int(65535) }}"
                       ### LABEL Font ###
                       - delay:
                           milliseconds: "{{ delay_value }}"
@@ -4889,7 +6281,7 @@ action:
                       - service: "{{ command_font_color }}"
                         data:
                           component: home.icon_top_03
-                          message: "{{ thermostat_icon_color }}"
+                          message: "{{ nextion_colors[thermostat_icon_color] | int(65535) }}"
                       ### ICON Thermostat Font ###
                       - delay:
                           milliseconds: "{{ delay_value }}"
@@ -4914,7 +6306,7 @@ action:
                   - service: "{{ command_font_color }}"
                     data:
                       component: home.icon_top_01
-                      message: "{{ relay01_icon_color }}"
+                      message: "{{ nextion_colors[relay01_icon_color] | int(65535) }}"
                   ### ICON Relay01 Font ###
                   - delay:
                       milliseconds: "{{ delay_value }}"
@@ -4929,7 +6321,7 @@ action:
                   - service: "{{ command_font_color }}"
                     data:
                       component: home.icon_top_02
-                      message: "{{ relay02_icon_color }}"
+                      message: "{{ nextion_colors[relay02_icon_color] | int(65535) }}"
                   ### ICON Relay02 Font ###
                   - delay:
                       milliseconds: "{{ delay_value }}"
@@ -4946,31 +6338,31 @@ action:
                         - position: home.icon_top_04
                           entity: "{{ chip01 }}"
                           entity_icon: "{{ chip01_icon }}"
-                          entity_icon_color: "{{ chip01_icon_color }}"
+                          entity_icon_color: "{{ nextion_colors[chip01_icon_color] | int(65535) }}"
                         - position: home.icon_top_05
                           entity: "{{ chip02 }}"
                           entity_icon: "{{ chip02_icon }}"
-                          entity_icon_color: "{{ chip02_icon_color }}"
+                          entity_icon_color: "{{ nextion_colors[chip02_icon_color] | int(65535) }}"
                         - position: home.icon_top_06
                           entity: "{{ chip03 }}"
                           entity_icon: "{{ chip03_icon }}"
-                          entity_icon_color: "{{ chip03_icon_color }}"
+                          entity_icon_color: "{{ nextion_colors[chip03_icon_color] | int(65535) }}"
                         - position: home.icon_top_07
                           entity: "{{ chip04 }}"
                           entity_icon: "{{ chip04_icon }}"
-                          entity_icon_color: "{{ chip04_icon_color }}"
+                          entity_icon_color: "{{ nextion_colors[chip04_icon_color] | int(65535) }}"
                         - position: home.icon_top_08
                           entity: "{{ chip05 }}"
                           entity_icon: "{{ chip05_icon }}"
-                          entity_icon_color: "{{ chip05_icon_color }}"
+                          entity_icon_color: "{{ nextion_colors[chip05_icon_color] | int(65535) }}"
                         - position: home.icon_top_09
                           entity: "{{ chip06 }}"
                           entity_icon: "{{ chip06_icon }}"
-                          entity_icon_color: "{{ chip06_icon_color }}"
+                          entity_icon_color: "{{ nextion_colors[chip06_icon_color] | int(65535) }}"
                         - position: home.icon_top_10
                           entity: "{{ chip07 }}"
                           entity_icon: "{{ chip07_icon }}"
-                          entity_icon_color: "{{ chip07_icon_color }}"
+                          entity_icon_color: "{{ nextion_colors[chip07_icon_color] | int(65535) }}"
                       sequence:
                         - if:
                             - condition: template
@@ -5002,18 +6394,18 @@ action:
                         - row: home.value01
                           entity: "{{ home_value01 }}"
                           entity_icon: "{{ home_value01_icon }}"
-                          entity_icon_color: "{{ home_value01_icon_color }}"
-                          entity_label_color: "{{ home_value01_label_color }}"
+                          entity_icon_color: "{{ nextion_colors[home_value01_icon_color] | int(65535) }}"
+                          entity_label_color: "{{ nextion_colors[home_value01_label_color] | int(65535) }}"
                         - row: home.value02
                           entity: "{{ home_value02 }}"
                           entity_icon: "{{ home_value02_icon }}"
-                          entity_icon_color: "{{ home_value02_icon_color }}"
-                          entity_label_color: "{{ home_value02_label_color }}"
+                          entity_icon_color: "{{ nextion_colors[home_value02_icon_color] | int(65535) }}"
+                          entity_label_color: "{{ nextion_colors[home_value02_label_color] | int(65535) }}"
                         - row: home.value03
                           entity: "{{ home_value03 }}"
                           entity_icon: "{{ home_value03_icon }}"
-                          entity_icon_color: "{{ home_value03_icon_color }}"
-                          entity_label_color: "{{ home_value03_label_color }}"
+                          entity_icon_color: "{{ nextion_colors[home_value03_icon_color] | int(65535) }}"
+                          entity_label_color: "{{ nextion_colors[home_value03_label_color] | int(65535) }}"
                       sequence:
                         - if:
                             - condition: template
@@ -5091,7 +6483,7 @@ action:
                       - service: "{{ command_font_color }}"
                         data:
                           component: home.button05_icon
-                          message: "{{ home_button05_icon_color }}"
+                          message: "{{ nextion_colors[home_button05_icon_color] | int(65535) }}"
                       ### ICON Font ###
                       - delay:
                           milliseconds: "{{ delay_value }}"
@@ -5112,7 +6504,7 @@ action:
                       - service: "{{ command_font_color }}"
                         data:
                           component: home.button06_icon
-                          message: "{{ home_button06_icon_color }}"
+                          message: "{{ nextion_colors[home_button06_icon_color] | int(65535) }}"
                       ### ICON Font ###
                       - delay:
                           milliseconds: "{{ delay_value }}"
@@ -5152,42 +6544,42 @@ action:
                         - entity: "{{ entity01 }}"
                           button_icon: "{{ entity01_icon }}"
                           button_label: "{{ entity01_name }}"
-                          button_icon_color: "{{ entity01_icon_color }}"
+                          button_icon_color: "{{ nextion_colors[entity01_icon_color] | int(65535) }}"
                           button: buttonpage01.button01
                         - entity: "{{ entity02 }}"
                           button_icon: "{{ entity02_icon }}"
                           button_label: "{{ entity02_name }}"
-                          button_icon_color: "{{ entity02_icon_color }}"
+                          button_icon_color: "{{ nextion_colors[entity02_icon_color] | int(65535) }}"
                           button: buttonpage01.button02
                         - entity: "{{ entity03 }}"
                           button_icon: "{{ entity03_icon }}"
                           button_label: "{{ entity03_name }}"
-                          button_icon_color: "{{ entity03_icon_color }}"
+                          button_icon_color: "{{ nextion_colors[entity03_icon_color] | int(65535) }}"
                           button: buttonpage01.button03
                         - entity: "{{ entity04 }}"
                           button_icon: "{{ entity04_icon }}"
                           button_label: "{{ entity04_name }}"
-                          button_icon_color: "{{ entity04_icon_color }}"
+                          button_icon_color: "{{ nextion_colors[entity04_icon_color] | int(65535) }}"
                           button: buttonpage01.button04
                         - entity: "{{ entity05 }}"
                           button_icon: "{{ entity05_icon }}"
                           button_label: "{{ entity05_name }}"
-                          button_icon_color: "{{ entity05_icon_color }}"
+                          button_icon_color: "{{ nextion_colors[entity05_icon_color] | int(65535) }}"
                           button: buttonpage01.button05
                         - entity: "{{ entity06 }}"
                           button_icon: "{{ entity06_icon }}"
                           button_label: "{{ entity06_name }}"
-                          button_icon_color: "{{ entity06_icon_color }}"
+                          button_icon_color: "{{ nextion_colors[entity06_icon_color] | int(65535) }}"
                           button: buttonpage01.button06
                         - entity: "{{ entity07 }}"
                           button_icon: "{{ entity07_icon }}"
                           button_label: "{{ entity07_name }}"
-                          button_icon_color: "{{ entity07_icon_color }}"
+                          button_icon_color: "{{ nextion_colors[entity07_icon_color] | int(65535) }}"
                           button: buttonpage01.button07
                         - entity: "{{ entity08 }}"
                           button_icon: "{{ entity08_icon }}"
                           button_label: "{{ entity08_name }}"
-                          button_icon_color: "{{ entity08_icon_color }}"
+                          button_icon_color: "{{ nextion_colors[entity08_icon_color] | int(65535) }}"
                           button: buttonpage01.button08
                       sequence:
                         - if:
@@ -5403,42 +6795,42 @@ action:
                         - entity: "{{ entity09 }}"
                           button_icon: "{{ entity09_icon }}"
                           button_label: "{{ entity09_name }}"
-                          button_icon_color: "{{ entity09_icon_color }}"
+                          button_icon_color: "{{ nextion_colors[entity09_icon_color] | int(65535) }}"
                           button: buttonpage02.button01
                         - entity: "{{ entity10 }}"
                           button_icon: "{{ entity10_icon }}"
                           button_label: "{{ entity10_name }}"
-                          button_icon_color: "{{ entity10_icon_color }}"
+                          button_icon_color: "{{ nextion_colors[entity10_icon_color] | int(65535) }}"
                           button: buttonpage02.button02
                         - entity: "{{ entity11 }}"
                           button_icon: "{{ entity11_icon }}"
                           button_label: "{{ entity11_name }}"
-                          button_icon_color: "{{ entity11_icon_color }}"
+                          button_icon_color: "{{ nextion_colors[entity11_icon_color] | int(65535) }}"
                           button: buttonpage02.button03
                         - entity: "{{ entity12 }}"
                           button_icon: "{{ entity12_icon }}"
                           button_label: "{{ entity12_name }}"
-                          button_icon_color: "{{ entity12_icon_color }}"
+                          button_icon_color: "{{ nextion_colors[entity12_icon_color] | int(65535) }}"
                           button: buttonpage02.button04
                         - entity: "{{ entity13 }}"
                           button_icon: "{{ entity13_icon }}"
                           button_label: "{{ entity13_name }}"
-                          button_icon_color: "{{ entity13_icon_color }}"
+                          button_icon_color: "{{ nextion_colors[entity13_icon_color] | int(65535) }}"
                           button: buttonpage02.button05
                         - entity: "{{ entity14 }}"
                           button_icon: "{{ entity14_icon }}"
                           button_label: "{{ entity14_name }}"
-                          button_icon_color: "{{ entity14_icon_color }}"
+                          button_icon_color: "{{ nextion_colors[entity14_icon_color] | int(65535) }}"
                           button: buttonpage02.button06
                         - entity: "{{ entity15 }}"
                           button_icon: "{{ entity15_icon }}"
                           button_label: "{{ entity15_name }}"
-                          button_icon_color: "{{ entity15_icon_color }}"
+                          button_icon_color: "{{ nextion_colors[entity15_icon_color] | int(65535) }}"
                           button: buttonpage02.button07
                         - entity: "{{ entity16 }}"
                           button_icon: "{{ entity16_icon }}"
                           button_label: "{{ entity16_name }}"
-                          button_icon_color: "{{ entity16_icon_color }}"
+                          button_icon_color: "{{ nextion_colors[entity16_icon_color] | int(65535) }}"
                           button: buttonpage02.button08
                       sequence:
                         - if:
@@ -5654,42 +7046,42 @@ action:
                         - entity: "{{ entity17 }}"
                           button_icon: "{{ entity17_icon }}"
                           button_label: "{{ entity17_name }}"
-                          button_icon_color: "{{ entity17_icon_color }}"
+                          button_icon_color: "{{ nextion_colors[entity17_icon_color] | int(65535) }}"
                           button: buttonpage03.button01
                         - entity: "{{ entity18 }}"
                           button_icon: "{{ entity18_icon }}"
                           button_label: "{{ entity18_name }}"
-                          button_icon_color: "{{ entity18_icon_color }}"
+                          button_icon_color: "{{ nextion_colors[entity18_icon_color] | int(65535) }}"
                           button: buttonpage03.button02
                         - entity: "{{ entity19 }}"
                           button_icon: "{{ entity19_icon }}"
                           button_label: "{{ entity19_name }}"
-                          button_icon_color: "{{ entity19_icon_color }}"
+                          button_icon_color: "{{ nextion_colors[entity19_icon_color] | int(65535) }}"
                           button: buttonpage03.button03
                         - entity: "{{ entity20 }}"
                           button_icon: "{{ entity20_icon }}"
                           button_label: "{{ entity20_name }}"
-                          button_icon_color: "{{ entity20_icon_color }}"
+                          button_icon_color: "{{ nextion_colors[entity20_icon_color] | int(65535) }}"
                           button: buttonpage03.button04
                         - entity: "{{ entity21 }}"
                           button_icon: "{{ entity21_icon }}"
                           button_label: "{{ entity21_name }}"
-                          button_icon_color: "{{ entity21_icon_color }}"
+                          button_icon_color: "{{ nextion_colors[entity21_icon_color] | int(65535) }}"
                           button: buttonpage03.button05
                         - entity: "{{ entity22 }}"
                           button_icon: "{{ entity22_icon }}"
                           button_label: "{{ entity22_name }}"
-                          button_icon_color: "{{ entity22_icon_color }}"
+                          button_icon_color: "{{ nextion_colors[entity22_icon_color] | int(65535) }}"
                           button: buttonpage03.button06
                         - entity: "{{ entity23 }}"
                           button_icon: "{{ entity23_icon }}"
                           button_label: "{{ entity23_name }}"
-                          button_icon_color: "{{ entity23_icon_color }}"
+                          button_icon_color: "{{ nextion_colors[entity23_icon_color] | int(65535) }}"
                           button: buttonpage03.button07
                         - entity: "{{ entity24 }}"
                           button_icon: "{{ entity24_icon }}"
                           button_label: "{{ entity24_name }}"
-                          button_icon_color: "{{ entity24_icon_color }}"
+                          button_icon_color: "{{ nextion_colors[entity24_icon_color] | int(65535) }}"
                           button: buttonpage03.button08
                       sequence:
                         - if:
@@ -5905,42 +7297,42 @@ action:
                         - entity: "{{ entity25 }}"
                           button_icon: "{{ entity25_icon }}"
                           button_label: "{{ entity25_name }}"
-                          button_icon_color: "{{ entity25_icon_color }}"
+                          button_icon_color: "{{ nextion_colors[entity25_icon_color] | int(65535) }}"
                           button: buttonpage04.button01
                         - entity: "{{ entity26 }}"
                           button_icon: "{{ entity26_icon }}"
                           button_label: "{{ entity26_name }}"
-                          button_icon_color: "{{ entity26_icon_color }}"
+                          button_icon_color: "{{ nextion_colors[entity26_icon_color] | int(65535) }}"
                           button: buttonpage04.button02
                         - entity: "{{ entity27 }}"
                           button_icon: "{{ entity27_icon }}"
                           button_label: "{{ entity27_name }}"
-                          button_icon_color: "{{ entity27_icon_color }}"
+                          button_icon_color: "{{ nextion_colors[entity27_icon_color] | int(65535) }}"
                           button: buttonpage04.button03
                         - entity: "{{ entity28 }}"
                           button_icon: "{{ entity28_icon }}"
                           button_label: "{{ entity28_name }}"
-                          button_icon_color: "{{ entity28_icon_color }}"
+                          button_icon_color: "{{ nextion_colors[entity28_icon_color] | int(65535) }}"
                           button: buttonpage04.button04
                         - entity: "{{ entity29 }}"
                           button_icon: "{{ entity29_icon }}"
                           button_label: "{{ entity29_name }}"
-                          button_icon_color: "{{ entity29_icon_color }}"
+                          button_icon_color: "{{ nextion_colors[entity29_icon_color] | int(65535) }}"
                           button: buttonpage04.button05
                         - entity: "{{ entity30 }}"
                           button_icon: "{{ entity30_icon }}"
                           button_label: "{{ entity30_name }}"
-                          button_icon_color: "{{ entity30_icon_color }}"
+                          button_icon_color: "{{ nextion_colors[entity30_icon_color] | int(65535) }}"
                           button: buttonpage04.button06
                         - entity: "{{ entity31 }}"
                           button_icon: "{{ entity31_icon }}"
                           button_label: "{{ entity31_name }}"
-                          button_icon_color: "{{ entity31_icon_color }}"
+                          button_icon_color: "{{ nextion_colors[entity31_icon_color] | int(65535) }}"
                           button: buttonpage04.button07
                         - entity: "{{ entity32 }}"
                           button_icon: "{{ entity32_icon }}"
                           button_label: "{{ entity32_name }}"
-                          button_icon_color: "{{ entity32_icon_color }}"
+                          button_icon_color: "{{ nextion_colors[entity32_icon_color] | int(65535) }}"
                           button: buttonpage04.button08
                       sequence:
                         - if:
@@ -8129,38 +9521,38 @@ action:
                 {%- endif -%}
               # ICON Font Color
               btn_icon_font: >-
-                {%- if trigger.entity_id == entity01 and ((trigger.to_state.state == 'on' or trigger.to_state.state == 'open') or (trigger.to_state.entity_id is match "button.") or (trigger.to_state.entity_id is match "input_button.") or (trigger.to_state.entity_id is match "scene.") or (trigger.to_state.entity_id is match "person." and trigger.to_state.state == 'home') or (trigger.to_state.entity_id is match "climate." and trigger.to_state.state != 'off') ) -%} {{ entity01_icon_color }}
-                {%- elif trigger.entity_id == entity02 and ((trigger.to_state.state == 'on' or trigger.to_state.state == 'open') or (trigger.to_state.entity_id is match "button.") or (trigger.to_state.entity_id is match "input_button.") or (trigger.to_state.entity_id is match "scene.") or (trigger.to_state.entity_id is match "person." and trigger.to_state.state == 'home') or (trigger.to_state.entity_id is match "climate." and trigger.to_state.state != 'off') ) -%} {{ entity02_icon_color }}
-                {%- elif trigger.entity_id == entity03 and ((trigger.to_state.state == 'on' or trigger.to_state.state == 'open') or (trigger.to_state.entity_id is match "button.") or (trigger.to_state.entity_id is match "input_button.") or (trigger.to_state.entity_id is match "scene.") or (trigger.to_state.entity_id is match "person." and trigger.to_state.state == 'home') or (trigger.to_state.entity_id is match "climate." and trigger.to_state.state != 'off') ) -%} {{ entity03_icon_color }}
-                {%- elif trigger.entity_id == entity04 and ((trigger.to_state.state == 'on' or trigger.to_state.state == 'open') or (trigger.to_state.entity_id is match "button.") or (trigger.to_state.entity_id is match "input_button.") or (trigger.to_state.entity_id is match "scene.") or (trigger.to_state.entity_id is match "person." and trigger.to_state.state == 'home') or (trigger.to_state.entity_id is match "climate." and trigger.to_state.state != 'off') ) -%} {{ entity04_icon_color }}
-                {%- elif trigger.entity_id == entity05 and ((trigger.to_state.state == 'on' or trigger.to_state.state == 'open') or (trigger.to_state.entity_id is match "button.") or (trigger.to_state.entity_id is match "input_button.") or (trigger.to_state.entity_id is match "scene.") or (trigger.to_state.entity_id is match "person." and trigger.to_state.state == 'home') or (trigger.to_state.entity_id is match "climate." and trigger.to_state.state != 'off') ) -%} {{ entity05_icon_color }}
-                {%- elif trigger.entity_id == entity06 and ((trigger.to_state.state == 'on' or trigger.to_state.state == 'open') or (trigger.to_state.entity_id is match "button.") or (trigger.to_state.entity_id is match "input_button.") or (trigger.to_state.entity_id is match "scene.") or (trigger.to_state.entity_id is match "person." and trigger.to_state.state == 'home') or (trigger.to_state.entity_id is match "climate." and trigger.to_state.state != 'off') ) -%} {{ entity06_icon_color }}
-                {%- elif trigger.entity_id == entity07 and ((trigger.to_state.state == 'on' or trigger.to_state.state == 'open') or (trigger.to_state.entity_id is match "button.") or (trigger.to_state.entity_id is match "input_button.") or (trigger.to_state.entity_id is match "scene.") or (trigger.to_state.entity_id is match "person." and trigger.to_state.state == 'home') or (trigger.to_state.entity_id is match "climate." and trigger.to_state.state != 'off') ) -%} {{ entity07_icon_color }}
-                {%- elif trigger.entity_id == entity08 and ((trigger.to_state.state == 'on' or trigger.to_state.state == 'open') or (trigger.to_state.entity_id is match "button.") or (trigger.to_state.entity_id is match "input_button.") or (trigger.to_state.entity_id is match "scene.") or (trigger.to_state.entity_id is match "person." and trigger.to_state.state == 'home') or (trigger.to_state.entity_id is match "climate." and trigger.to_state.state != 'off') ) -%} {{ entity08_icon_color }}
-                {%- elif trigger.entity_id == entity09 and ((trigger.to_state.state == 'on' or trigger.to_state.state == 'open') or (trigger.to_state.entity_id is match "button.") or (trigger.to_state.entity_id is match "input_button.") or (trigger.to_state.entity_id is match "scene.") or (trigger.to_state.entity_id is match "person." and trigger.to_state.state == 'home') or (trigger.to_state.entity_id is match "climate." and trigger.to_state.state != 'off') ) -%} {{ entity09_icon_color }}
-                {%- elif trigger.entity_id == entity10 and ((trigger.to_state.state == 'on' or trigger.to_state.state == 'open') or (trigger.to_state.entity_id is match "button.") or (trigger.to_state.entity_id is match "input_button.") or (trigger.to_state.entity_id is match "scene.") or (trigger.to_state.entity_id is match "person." and trigger.to_state.state == 'home') or (trigger.to_state.entity_id is match "climate." and trigger.to_state.state != 'off') ) -%} {{ entity10_icon_color }}
-                {%- elif trigger.entity_id == entity11 and ((trigger.to_state.state == 'on' or trigger.to_state.state == 'open') or (trigger.to_state.entity_id is match "button.") or (trigger.to_state.entity_id is match "input_button.") or (trigger.to_state.entity_id is match "scene.") or (trigger.to_state.entity_id is match "person." and trigger.to_state.state == 'home') or (trigger.to_state.entity_id is match "climate." and trigger.to_state.state != 'off') ) -%} {{ entity11_icon_color }}
-                {%- elif trigger.entity_id == entity12 and ((trigger.to_state.state == 'on' or trigger.to_state.state == 'open') or (trigger.to_state.entity_id is match "button.") or (trigger.to_state.entity_id is match "input_button.") or (trigger.to_state.entity_id is match "scene.") or (trigger.to_state.entity_id is match "person." and trigger.to_state.state == 'home') or (trigger.to_state.entity_id is match "climate." and trigger.to_state.state != 'off') ) -%} {{ entity12_icon_color }}
-                {%- elif trigger.entity_id == entity13 and ((trigger.to_state.state == 'on' or trigger.to_state.state == 'open') or (trigger.to_state.entity_id is match "button.") or (trigger.to_state.entity_id is match "input_button.") or (trigger.to_state.entity_id is match "scene.") or (trigger.to_state.entity_id is match "person." and trigger.to_state.state == 'home') or (trigger.to_state.entity_id is match "climate." and trigger.to_state.state != 'off') ) -%} {{ entity13_icon_color }}
-                {%- elif trigger.entity_id == entity14 and ((trigger.to_state.state == 'on' or trigger.to_state.state == 'open') or (trigger.to_state.entity_id is match "button.") or (trigger.to_state.entity_id is match "input_button.") or (trigger.to_state.entity_id is match "scene.") or (trigger.to_state.entity_id is match "person." and trigger.to_state.state == 'home') or (trigger.to_state.entity_id is match "climate." and trigger.to_state.state != 'off') ) -%} {{ entity14_icon_color }}
-                {%- elif trigger.entity_id == entity15 and ((trigger.to_state.state == 'on' or trigger.to_state.state == 'open') or (trigger.to_state.entity_id is match "button.") or (trigger.to_state.entity_id is match "input_button.") or (trigger.to_state.entity_id is match "scene.") or (trigger.to_state.entity_id is match "person." and trigger.to_state.state == 'home') or (trigger.to_state.entity_id is match "climate." and trigger.to_state.state != 'off') ) -%} {{ entity15_icon_color }}
-                {%- elif trigger.entity_id == entity16 and ((trigger.to_state.state == 'on' or trigger.to_state.state == 'open') or (trigger.to_state.entity_id is match "button.") or (trigger.to_state.entity_id is match "input_button.") or (trigger.to_state.entity_id is match "scene.") or (trigger.to_state.entity_id is match "person." and trigger.to_state.state == 'home') or (trigger.to_state.entity_id is match "climate." and trigger.to_state.state != 'off') ) -%} {{ entity16_icon_color }}
-                {%- elif trigger.entity_id == entity17 and ((trigger.to_state.state == 'on' or trigger.to_state.state == 'open') or (trigger.to_state.entity_id is match "button.") or (trigger.to_state.entity_id is match "input_button.") or (trigger.to_state.entity_id is match "scene.") or (trigger.to_state.entity_id is match "person." and trigger.to_state.state == 'home') or (trigger.to_state.entity_id is match "climate." and trigger.to_state.state != 'off') ) -%} {{ entity17_icon_color }}
-                {%- elif trigger.entity_id == entity18 and ((trigger.to_state.state == 'on' or trigger.to_state.state == 'open') or (trigger.to_state.entity_id is match "button.") or (trigger.to_state.entity_id is match "input_button.") or (trigger.to_state.entity_id is match "scene.") or (trigger.to_state.entity_id is match "person." and trigger.to_state.state == 'home') or (trigger.to_state.entity_id is match "climate." and trigger.to_state.state != 'off') ) -%} {{ entity18_icon_color }}
-                {%- elif trigger.entity_id == entity19 and ((trigger.to_state.state == 'on' or trigger.to_state.state == 'open') or (trigger.to_state.entity_id is match "button.") or (trigger.to_state.entity_id is match "input_button.") or (trigger.to_state.entity_id is match "scene.") or (trigger.to_state.entity_id is match "person." and trigger.to_state.state == 'home') or (trigger.to_state.entity_id is match "climate." and trigger.to_state.state != 'off') ) -%} {{ entity19_icon_color }}
-                {%- elif trigger.entity_id == entity20 and ((trigger.to_state.state == 'on' or trigger.to_state.state == 'open') or (trigger.to_state.entity_id is match "button.") or (trigger.to_state.entity_id is match "input_button.") or (trigger.to_state.entity_id is match "scene.") or (trigger.to_state.entity_id is match "person." and trigger.to_state.state == 'home') or (trigger.to_state.entity_id is match "climate." and trigger.to_state.state != 'off') ) -%} {{ entity20_icon_color }}
-                {%- elif trigger.entity_id == entity21 and ((trigger.to_state.state == 'on' or trigger.to_state.state == 'open') or (trigger.to_state.entity_id is match "button.") or (trigger.to_state.entity_id is match "input_button.") or (trigger.to_state.entity_id is match "scene.") or (trigger.to_state.entity_id is match "person." and trigger.to_state.state == 'home') or (trigger.to_state.entity_id is match "climate." and trigger.to_state.state != 'off') ) -%} {{ entity21_icon_color }}
-                {%- elif trigger.entity_id == entity22 and ((trigger.to_state.state == 'on' or trigger.to_state.state == 'open') or (trigger.to_state.entity_id is match "button.") or (trigger.to_state.entity_id is match "input_button.") or (trigger.to_state.entity_id is match "scene.") or (trigger.to_state.entity_id is match "person." and trigger.to_state.state == 'home') or (trigger.to_state.entity_id is match "climate." and trigger.to_state.state != 'off') ) -%} {{ entity22_icon_color }}
-                {%- elif trigger.entity_id == entity23 and ((trigger.to_state.state == 'on' or trigger.to_state.state == 'open') or (trigger.to_state.entity_id is match "button.") or (trigger.to_state.entity_id is match "input_button.") or (trigger.to_state.entity_id is match "scene.") or (trigger.to_state.entity_id is match "person." and trigger.to_state.state == 'home') or (trigger.to_state.entity_id is match "climate." and trigger.to_state.state != 'off') ) -%} {{ entity23_icon_color }}
-                {%- elif trigger.entity_id == entity24 and ((trigger.to_state.state == 'on' or trigger.to_state.state == 'open') or (trigger.to_state.entity_id is match "button.") or (trigger.to_state.entity_id is match "input_button.") or (trigger.to_state.entity_id is match "scene.") or (trigger.to_state.entity_id is match "person." and trigger.to_state.state == 'home') or (trigger.to_state.entity_id is match "climate." and trigger.to_state.state != 'off') ) -%} {{ entity24_icon_color }}
-                {%- elif trigger.entity_id == entity25 and ((trigger.to_state.state == 'on' or trigger.to_state.state == 'open') or (trigger.to_state.entity_id is match "button.") or (trigger.to_state.entity_id is match "input_button.") or (trigger.to_state.entity_id is match "scene.") or (trigger.to_state.entity_id is match "person." and trigger.to_state.state == 'home') or (trigger.to_state.entity_id is match "climate." and trigger.to_state.state != 'off') ) -%} {{ entity25_icon_color }}
-                {%- elif trigger.entity_id == entity26 and ((trigger.to_state.state == 'on' or trigger.to_state.state == 'open') or (trigger.to_state.entity_id is match "button.") or (trigger.to_state.entity_id is match "input_button.") or (trigger.to_state.entity_id is match "scene.") or (trigger.to_state.entity_id is match "person." and trigger.to_state.state == 'home') or (trigger.to_state.entity_id is match "climate." and trigger.to_state.state != 'off') ) -%} {{ entity26_icon_color }}
-                {%- elif trigger.entity_id == entity27 and ((trigger.to_state.state == 'on' or trigger.to_state.state == 'open') or (trigger.to_state.entity_id is match "button.") or (trigger.to_state.entity_id is match "input_button.") or (trigger.to_state.entity_id is match "scene.") or (trigger.to_state.entity_id is match "person." and trigger.to_state.state == 'home') or (trigger.to_state.entity_id is match "climate." and trigger.to_state.state != 'off') ) -%} {{ entity27_icon_color }}
-                {%- elif trigger.entity_id == entity28 and ((trigger.to_state.state == 'on' or trigger.to_state.state == 'open') or (trigger.to_state.entity_id is match "button.") or (trigger.to_state.entity_id is match "input_button.") or (trigger.to_state.entity_id is match "scene.") or (trigger.to_state.entity_id is match "person." and trigger.to_state.state == 'home') or (trigger.to_state.entity_id is match "climate." and trigger.to_state.state != 'off') ) -%} {{ entity28_icon_color }}
-                {%- elif trigger.entity_id == entity29 and ((trigger.to_state.state == 'on' or trigger.to_state.state == 'open') or (trigger.to_state.entity_id is match "button.") or (trigger.to_state.entity_id is match "input_button.") or (trigger.to_state.entity_id is match "scene.") or (trigger.to_state.entity_id is match "person." and trigger.to_state.state == 'home') or (trigger.to_state.entity_id is match "climate." and trigger.to_state.state != 'off') ) -%} {{ entity29_icon_color }}
-                {%- elif trigger.entity_id == entity30 and ((trigger.to_state.state == 'on' or trigger.to_state.state == 'open') or (trigger.to_state.entity_id is match "button.") or (trigger.to_state.entity_id is match "input_button.") or (trigger.to_state.entity_id is match "scene.") or (trigger.to_state.entity_id is match "person." and trigger.to_state.state == 'home') or (trigger.to_state.entity_id is match "climate." and trigger.to_state.state != 'off') ) -%} {{ entity30_icon_color }}
-                {%- elif trigger.entity_id == entity31 and ((trigger.to_state.state == 'on' or trigger.to_state.state == 'open') or (trigger.to_state.entity_id is match "button.") or (trigger.to_state.entity_id is match "input_button.") or (trigger.to_state.entity_id is match "scene.") or (trigger.to_state.entity_id is match "person." and trigger.to_state.state == 'home') or (trigger.to_state.entity_id is match "climate." and trigger.to_state.state != 'off') ) -%} {{ entity31_icon_color }}
-                {%- elif trigger.entity_id == entity32 and ((trigger.to_state.state == 'on' or trigger.to_state.state == 'open') or (trigger.to_state.entity_id is match "button.") or (trigger.to_state.entity_id is match "input_button.") or (trigger.to_state.entity_id is match "scene.") or (trigger.to_state.entity_id is match "person." and trigger.to_state.state == 'home') or (trigger.to_state.entity_id is match "climate." and trigger.to_state.state != 'off') ) -%} {{ entity32_icon_color }}
+                {%- if trigger.entity_id == entity01 and ((trigger.to_state.state == 'on' or trigger.to_state.state == 'open') or (trigger.to_state.entity_id is match "button.") or (trigger.to_state.entity_id is match "input_button.") or (trigger.to_state.entity_id is match "scene.") or (trigger.to_state.entity_id is match "person." and trigger.to_state.state == 'home') or (trigger.to_state.entity_id is match "climate." and trigger.to_state.state != 'off') ) -%} {{ nextion_colors[entity01_icon_color] | int(65535) }}
+                {%- elif trigger.entity_id == entity02 and ((trigger.to_state.state == 'on' or trigger.to_state.state == 'open') or (trigger.to_state.entity_id is match "button.") or (trigger.to_state.entity_id is match "input_button.") or (trigger.to_state.entity_id is match "scene.") or (trigger.to_state.entity_id is match "person." and trigger.to_state.state == 'home') or (trigger.to_state.entity_id is match "climate." and trigger.to_state.state != 'off') ) -%} {{ nextion_colors[entity02_icon_color] | int(65535) }}
+                {%- elif trigger.entity_id == entity03 and ((trigger.to_state.state == 'on' or trigger.to_state.state == 'open') or (trigger.to_state.entity_id is match "button.") or (trigger.to_state.entity_id is match "input_button.") or (trigger.to_state.entity_id is match "scene.") or (trigger.to_state.entity_id is match "person." and trigger.to_state.state == 'home') or (trigger.to_state.entity_id is match "climate." and trigger.to_state.state != 'off') ) -%} {{ nextion_colors[entity03_icon_color] | int(65535) }}
+                {%- elif trigger.entity_id == entity04 and ((trigger.to_state.state == 'on' or trigger.to_state.state == 'open') or (trigger.to_state.entity_id is match "button.") or (trigger.to_state.entity_id is match "input_button.") or (trigger.to_state.entity_id is match "scene.") or (trigger.to_state.entity_id is match "person." and trigger.to_state.state == 'home') or (trigger.to_state.entity_id is match "climate." and trigger.to_state.state != 'off') ) -%} {{ nextion_colors[entity04_icon_color] | int(65535) }}
+                {%- elif trigger.entity_id == entity05 and ((trigger.to_state.state == 'on' or trigger.to_state.state == 'open') or (trigger.to_state.entity_id is match "button.") or (trigger.to_state.entity_id is match "input_button.") or (trigger.to_state.entity_id is match "scene.") or (trigger.to_state.entity_id is match "person." and trigger.to_state.state == 'home') or (trigger.to_state.entity_id is match "climate." and trigger.to_state.state != 'off') ) -%} {{ nextion_colors[entity05_icon_color] | int(65535) }}
+                {%- elif trigger.entity_id == entity06 and ((trigger.to_state.state == 'on' or trigger.to_state.state == 'open') or (trigger.to_state.entity_id is match "button.") or (trigger.to_state.entity_id is match "input_button.") or (trigger.to_state.entity_id is match "scene.") or (trigger.to_state.entity_id is match "person." and trigger.to_state.state == 'home') or (trigger.to_state.entity_id is match "climate." and trigger.to_state.state != 'off') ) -%} {{ nextion_colors[entity06_icon_color] | int(65535) }}
+                {%- elif trigger.entity_id == entity07 and ((trigger.to_state.state == 'on' or trigger.to_state.state == 'open') or (trigger.to_state.entity_id is match "button.") or (trigger.to_state.entity_id is match "input_button.") or (trigger.to_state.entity_id is match "scene.") or (trigger.to_state.entity_id is match "person." and trigger.to_state.state == 'home') or (trigger.to_state.entity_id is match "climate." and trigger.to_state.state != 'off') ) -%} {{ nextion_colors[entity07_icon_color] | int(65535) }}
+                {%- elif trigger.entity_id == entity08 and ((trigger.to_state.state == 'on' or trigger.to_state.state == 'open') or (trigger.to_state.entity_id is match "button.") or (trigger.to_state.entity_id is match "input_button.") or (trigger.to_state.entity_id is match "scene.") or (trigger.to_state.entity_id is match "person." and trigger.to_state.state == 'home') or (trigger.to_state.entity_id is match "climate." and trigger.to_state.state != 'off') ) -%} {{ nextion_colors[entity08_icon_color] | int(65535) }}
+                {%- elif trigger.entity_id == entity09 and ((trigger.to_state.state == 'on' or trigger.to_state.state == 'open') or (trigger.to_state.entity_id is match "button.") or (trigger.to_state.entity_id is match "input_button.") or (trigger.to_state.entity_id is match "scene.") or (trigger.to_state.entity_id is match "person." and trigger.to_state.state == 'home') or (trigger.to_state.entity_id is match "climate." and trigger.to_state.state != 'off') ) -%} {{ nextion_colors[entity09_icon_color] | int(65535) }}
+                {%- elif trigger.entity_id == entity10 and ((trigger.to_state.state == 'on' or trigger.to_state.state == 'open') or (trigger.to_state.entity_id is match "button.") or (trigger.to_state.entity_id is match "input_button.") or (trigger.to_state.entity_id is match "scene.") or (trigger.to_state.entity_id is match "person." and trigger.to_state.state == 'home') or (trigger.to_state.entity_id is match "climate." and trigger.to_state.state != 'off') ) -%} {{ nextion_colors[entity10_icon_color] | int(65535) }}
+                {%- elif trigger.entity_id == entity11 and ((trigger.to_state.state == 'on' or trigger.to_state.state == 'open') or (trigger.to_state.entity_id is match "button.") or (trigger.to_state.entity_id is match "input_button.") or (trigger.to_state.entity_id is match "scene.") or (trigger.to_state.entity_id is match "person." and trigger.to_state.state == 'home') or (trigger.to_state.entity_id is match "climate." and trigger.to_state.state != 'off') ) -%} {{ nextion_colors[entity11_icon_color] | int(65535) }}
+                {%- elif trigger.entity_id == entity12 and ((trigger.to_state.state == 'on' or trigger.to_state.state == 'open') or (trigger.to_state.entity_id is match "button.") or (trigger.to_state.entity_id is match "input_button.") or (trigger.to_state.entity_id is match "scene.") or (trigger.to_state.entity_id is match "person." and trigger.to_state.state == 'home') or (trigger.to_state.entity_id is match "climate." and trigger.to_state.state != 'off') ) -%} {{ nextion_colors[entity12_icon_color] | int(65535) }}
+                {%- elif trigger.entity_id == entity13 and ((trigger.to_state.state == 'on' or trigger.to_state.state == 'open') or (trigger.to_state.entity_id is match "button.") or (trigger.to_state.entity_id is match "input_button.") or (trigger.to_state.entity_id is match "scene.") or (trigger.to_state.entity_id is match "person." and trigger.to_state.state == 'home') or (trigger.to_state.entity_id is match "climate." and trigger.to_state.state != 'off') ) -%} {{ nextion_colors[entity13_icon_color] | int(65535) }}
+                {%- elif trigger.entity_id == entity14 and ((trigger.to_state.state == 'on' or trigger.to_state.state == 'open') or (trigger.to_state.entity_id is match "button.") or (trigger.to_state.entity_id is match "input_button.") or (trigger.to_state.entity_id is match "scene.") or (trigger.to_state.entity_id is match "person." and trigger.to_state.state == 'home') or (trigger.to_state.entity_id is match "climate." and trigger.to_state.state != 'off') ) -%} {{ nextion_colors[entity14_icon_color] | int(65535) }}
+                {%- elif trigger.entity_id == entity15 and ((trigger.to_state.state == 'on' or trigger.to_state.state == 'open') or (trigger.to_state.entity_id is match "button.") or (trigger.to_state.entity_id is match "input_button.") or (trigger.to_state.entity_id is match "scene.") or (trigger.to_state.entity_id is match "person." and trigger.to_state.state == 'home') or (trigger.to_state.entity_id is match "climate." and trigger.to_state.state != 'off') ) -%} {{ nextion_colors[entity15_icon_color] | int(65535) }}
+                {%- elif trigger.entity_id == entity16 and ((trigger.to_state.state == 'on' or trigger.to_state.state == 'open') or (trigger.to_state.entity_id is match "button.") or (trigger.to_state.entity_id is match "input_button.") or (trigger.to_state.entity_id is match "scene.") or (trigger.to_state.entity_id is match "person." and trigger.to_state.state == 'home') or (trigger.to_state.entity_id is match "climate." and trigger.to_state.state != 'off') ) -%} {{ nextion_colors[entity16_icon_color] | int(65535) }}
+                {%- elif trigger.entity_id == entity17 and ((trigger.to_state.state == 'on' or trigger.to_state.state == 'open') or (trigger.to_state.entity_id is match "button.") or (trigger.to_state.entity_id is match "input_button.") or (trigger.to_state.entity_id is match "scene.") or (trigger.to_state.entity_id is match "person." and trigger.to_state.state == 'home') or (trigger.to_state.entity_id is match "climate." and trigger.to_state.state != 'off') ) -%} {{ nextion_colors[entity17_icon_color] | int(65535) }}
+                {%- elif trigger.entity_id == entity18 and ((trigger.to_state.state == 'on' or trigger.to_state.state == 'open') or (trigger.to_state.entity_id is match "button.") or (trigger.to_state.entity_id is match "input_button.") or (trigger.to_state.entity_id is match "scene.") or (trigger.to_state.entity_id is match "person." and trigger.to_state.state == 'home') or (trigger.to_state.entity_id is match "climate." and trigger.to_state.state != 'off') ) -%} {{ nextion_colors[entity18_icon_color] | int(65535) }}
+                {%- elif trigger.entity_id == entity19 and ((trigger.to_state.state == 'on' or trigger.to_state.state == 'open') or (trigger.to_state.entity_id is match "button.") or (trigger.to_state.entity_id is match "input_button.") or (trigger.to_state.entity_id is match "scene.") or (trigger.to_state.entity_id is match "person." and trigger.to_state.state == 'home') or (trigger.to_state.entity_id is match "climate." and trigger.to_state.state != 'off') ) -%} {{ nextion_colors[entity19_icon_color] | int(65535) }}
+                {%- elif trigger.entity_id == entity20 and ((trigger.to_state.state == 'on' or trigger.to_state.state == 'open') or (trigger.to_state.entity_id is match "button.") or (trigger.to_state.entity_id is match "input_button.") or (trigger.to_state.entity_id is match "scene.") or (trigger.to_state.entity_id is match "person." and trigger.to_state.state == 'home') or (trigger.to_state.entity_id is match "climate." and trigger.to_state.state != 'off') ) -%} {{ nextion_colors[entity20_icon_color] | int(65535) }}
+                {%- elif trigger.entity_id == entity21 and ((trigger.to_state.state == 'on' or trigger.to_state.state == 'open') or (trigger.to_state.entity_id is match "button.") or (trigger.to_state.entity_id is match "input_button.") or (trigger.to_state.entity_id is match "scene.") or (trigger.to_state.entity_id is match "person." and trigger.to_state.state == 'home') or (trigger.to_state.entity_id is match "climate." and trigger.to_state.state != 'off') ) -%} {{ nextion_colors[entity21_icon_color] | int(65535) }}
+                {%- elif trigger.entity_id == entity22 and ((trigger.to_state.state == 'on' or trigger.to_state.state == 'open') or (trigger.to_state.entity_id is match "button.") or (trigger.to_state.entity_id is match "input_button.") or (trigger.to_state.entity_id is match "scene.") or (trigger.to_state.entity_id is match "person." and trigger.to_state.state == 'home') or (trigger.to_state.entity_id is match "climate." and trigger.to_state.state != 'off') ) -%} {{ nextion_colors[entity22_icon_color] | int(65535) }}
+                {%- elif trigger.entity_id == entity23 and ((trigger.to_state.state == 'on' or trigger.to_state.state == 'open') or (trigger.to_state.entity_id is match "button.") or (trigger.to_state.entity_id is match "input_button.") or (trigger.to_state.entity_id is match "scene.") or (trigger.to_state.entity_id is match "person." and trigger.to_state.state == 'home') or (trigger.to_state.entity_id is match "climate." and trigger.to_state.state != 'off') ) -%} {{ nextion_colors[entity23_icon_color] | int(65535) }}
+                {%- elif trigger.entity_id == entity24 and ((trigger.to_state.state == 'on' or trigger.to_state.state == 'open') or (trigger.to_state.entity_id is match "button.") or (trigger.to_state.entity_id is match "input_button.") or (trigger.to_state.entity_id is match "scene.") or (trigger.to_state.entity_id is match "person." and trigger.to_state.state == 'home') or (trigger.to_state.entity_id is match "climate." and trigger.to_state.state != 'off') ) -%} {{ nextion_colors[entity24_icon_color] | int(65535) }}
+                {%- elif trigger.entity_id == entity25 and ((trigger.to_state.state == 'on' or trigger.to_state.state == 'open') or (trigger.to_state.entity_id is match "button.") or (trigger.to_state.entity_id is match "input_button.") or (trigger.to_state.entity_id is match "scene.") or (trigger.to_state.entity_id is match "person." and trigger.to_state.state == 'home') or (trigger.to_state.entity_id is match "climate." and trigger.to_state.state != 'off') ) -%} {{ nextion_colors[entity25_icon_color] | int(65535) }}
+                {%- elif trigger.entity_id == entity26 and ((trigger.to_state.state == 'on' or trigger.to_state.state == 'open') or (trigger.to_state.entity_id is match "button.") or (trigger.to_state.entity_id is match "input_button.") or (trigger.to_state.entity_id is match "scene.") or (trigger.to_state.entity_id is match "person." and trigger.to_state.state == 'home') or (trigger.to_state.entity_id is match "climate." and trigger.to_state.state != 'off') ) -%} {{ nextion_colors[entity26_icon_color] | int(65535) }}
+                {%- elif trigger.entity_id == entity27 and ((trigger.to_state.state == 'on' or trigger.to_state.state == 'open') or (trigger.to_state.entity_id is match "button.") or (trigger.to_state.entity_id is match "input_button.") or (trigger.to_state.entity_id is match "scene.") or (trigger.to_state.entity_id is match "person." and trigger.to_state.state == 'home') or (trigger.to_state.entity_id is match "climate." and trigger.to_state.state != 'off') ) -%} {{ nextion_colors[entity27_icon_color] | int(65535) }}
+                {%- elif trigger.entity_id == entity28 and ((trigger.to_state.state == 'on' or trigger.to_state.state == 'open') or (trigger.to_state.entity_id is match "button.") or (trigger.to_state.entity_id is match "input_button.") or (trigger.to_state.entity_id is match "scene.") or (trigger.to_state.entity_id is match "person." and trigger.to_state.state == 'home') or (trigger.to_state.entity_id is match "climate." and trigger.to_state.state != 'off') ) -%} {{ nextion_colors[entity28_icon_color] | int(65535) }}
+                {%- elif trigger.entity_id == entity29 and ((trigger.to_state.state == 'on' or trigger.to_state.state == 'open') or (trigger.to_state.entity_id is match "button.") or (trigger.to_state.entity_id is match "input_button.") or (trigger.to_state.entity_id is match "scene.") or (trigger.to_state.entity_id is match "person." and trigger.to_state.state == 'home') or (trigger.to_state.entity_id is match "climate." and trigger.to_state.state != 'off') ) -%} {{ nextion_colors[entity29_icon_color] | int(65535) }}
+                {%- elif trigger.entity_id == entity30 and ((trigger.to_state.state == 'on' or trigger.to_state.state == 'open') or (trigger.to_state.entity_id is match "button.") or (trigger.to_state.entity_id is match "input_button.") or (trigger.to_state.entity_id is match "scene.") or (trigger.to_state.entity_id is match "person." and trigger.to_state.state == 'home') or (trigger.to_state.entity_id is match "climate." and trigger.to_state.state != 'off') ) -%} {{ nextion_colors[entity30_icon_color] | int(65535) }}
+                {%- elif trigger.entity_id == entity31 and ((trigger.to_state.state == 'on' or trigger.to_state.state == 'open') or (trigger.to_state.entity_id is match "button.") or (trigger.to_state.entity_id is match "input_button.") or (trigger.to_state.entity_id is match "scene.") or (trigger.to_state.entity_id is match "person." and trigger.to_state.state == 'home') or (trigger.to_state.entity_id is match "climate." and trigger.to_state.state != 'off') ) -%} {{ nextion_colors[entity31_icon_color] | int(65535) }}
+                {%- elif trigger.entity_id == entity32 and ((trigger.to_state.state == 'on' or trigger.to_state.state == 'open') or (trigger.to_state.entity_id is match "button.") or (trigger.to_state.entity_id is match "input_button.") or (trigger.to_state.entity_id is match "scene.") or (trigger.to_state.entity_id is match "person." and trigger.to_state.state == 'home') or (trigger.to_state.entity_id is match "climate." and trigger.to_state.state != 'off') ) -%} {{ nextion_colors[entity32_icon_color] | int(65535) }}
                 {%- elif trigger.to_state.state == 'off' or trigger.to_state.state == 'closed' -%} {{ nextion_colors.graylight }}
                 {%- elif trigger.to_state.entity_id is match "person." and trigger.to_state.state != 'home' -%} {{ nextion_colors.graylight }}
                 {%- elif trigger.to_state.entity_id is match "climate." and trigger.to_state.state == 'off' -%} {{ nextion_colors.graylight }}
@@ -8845,38 +10237,38 @@ action:
 
               ##### Long Press Entity Icon Color #####
               entity_long_icon_color: >-
-                {%- if trigger.to_state.state == "pressbuttonpage01button01" -%} {{ entity01_icon_color }}
-                {%- elif trigger.to_state.state == "pressbuttonpage01button02" -%} {{ entity02_icon_color }}
-                {%- elif trigger.to_state.state == "pressbuttonpage01button03" -%} {{ entity03_icon_color }}
-                {%- elif trigger.to_state.state == "pressbuttonpage01button04" -%} {{ entity04_icon_color }}
-                {%- elif trigger.to_state.state == "pressbuttonpage01button05" -%} {{ entity05_icon_color }}
-                {%- elif trigger.to_state.state == "pressbuttonpage01button06" -%} {{ entity06_icon_color }}
-                {%- elif trigger.to_state.state == "pressbuttonpage01button07" -%} {{ entity07_icon_color }}
-                {%- elif trigger.to_state.state == "pressbuttonpage01button08" -%} {{ entity08_icon_color }}
-                {%- elif trigger.to_state.state == "pressbuttonpage02button01" -%} {{ entity09_icon_color }}
-                {%- elif trigger.to_state.state == "pressbuttonpage02button02" -%} {{ entity10_icon_color }}
-                {%- elif trigger.to_state.state == "pressbuttonpage02button03" -%} {{ entity11_icon_color }}
-                {%- elif trigger.to_state.state == "pressbuttonpage02button04" -%} {{ entity12_icon_color }}
-                {%- elif trigger.to_state.state == "pressbuttonpage02button05" -%} {{ entity13_icon_color }}
-                {%- elif trigger.to_state.state == "pressbuttonpage02button06" -%} {{ entity14_icon_color }}
-                {%- elif trigger.to_state.state == "pressbuttonpage02button07" -%} {{ entity15_icon_color }}
-                {%- elif trigger.to_state.state == "pressbuttonpage02button08" -%} {{ entity16_icon_color }}
-                {%- elif trigger.to_state.state == "pressbuttonpage03button01" -%} {{ entity17_icon_color }}
-                {%- elif trigger.to_state.state == "pressbuttonpage03button02" -%} {{ entity18_icon_color }}
-                {%- elif trigger.to_state.state == "pressbuttonpage03button03" -%} {{ entity19_icon_color }}
-                {%- elif trigger.to_state.state == "pressbuttonpage03button04" -%} {{ entity20_icon_color }}
-                {%- elif trigger.to_state.state == "pressbuttonpage03button05" -%} {{ entity21_icon_color }}
-                {%- elif trigger.to_state.state == "pressbuttonpage03button06" -%} {{ entity22_icon_color }}
-                {%- elif trigger.to_state.state == "pressbuttonpage03button07" -%} {{ entity23_icon_color }}
-                {%- elif trigger.to_state.state == "pressbuttonpage03button08" -%} {{ entity24_icon_color }}
-                {%- elif trigger.to_state.state == "pressbuttonpage04button01" -%} {{ entity25_icon_color }}
-                {%- elif trigger.to_state.state == "pressbuttonpage04button02" -%} {{ entity26_icon_color }}
-                {%- elif trigger.to_state.state == "pressbuttonpage04button03" -%} {{ entity27_icon_color }}
-                {%- elif trigger.to_state.state == "pressbuttonpage04button04" -%} {{ entity28_icon_color }}
-                {%- elif trigger.to_state.state == "pressbuttonpage04button05" -%} {{ entity29_icon_color }}
-                {%- elif trigger.to_state.state == "pressbuttonpage04button06" -%} {{ entity30_icon_color }}
-                {%- elif trigger.to_state.state == "pressbuttonpage04button07" -%} {{ entity31_icon_color }}
-                {%- elif trigger.to_state.state == "pressbuttonpage04button08" -%} {{ entity32_icon_color }}
+                {%- if trigger.to_state.state == "pressbuttonpage01button01" -%} {{ nextion_colors[entity01_icon_color] | int(65535) }}
+                {%- elif trigger.to_state.state == "pressbuttonpage01button02" -%} {{ nextion_colors[entity02_icon_color] | int(65535) }}
+                {%- elif trigger.to_state.state == "pressbuttonpage01button03" -%} {{ nextion_colors[entity03_icon_color] | int(65535) }}
+                {%- elif trigger.to_state.state == "pressbuttonpage01button04" -%} {{ nextion_colors[entity04_icon_color] | int(65535) }}
+                {%- elif trigger.to_state.state == "pressbuttonpage01button05" -%} {{ nextion_colors[entity05_icon_color] | int(65535) }}
+                {%- elif trigger.to_state.state == "pressbuttonpage01button06" -%} {{ nextion_colors[entity06_icon_color] | int(65535) }}
+                {%- elif trigger.to_state.state == "pressbuttonpage01button07" -%} {{ nextion_colors[entity07_icon_color] | int(65535) }}
+                {%- elif trigger.to_state.state == "pressbuttonpage01button08" -%} {{ nextion_colors[entity08_icon_color] | int(65535) }}
+                {%- elif trigger.to_state.state == "pressbuttonpage02button01" -%} {{ nextion_colors[entity09_icon_color] | int(65535) }}
+                {%- elif trigger.to_state.state == "pressbuttonpage02button02" -%} {{ nextion_colors[entity10_icon_color] | int(65535) }}
+                {%- elif trigger.to_state.state == "pressbuttonpage02button03" -%} {{ nextion_colors[entity11_icon_color] | int(65535) }}
+                {%- elif trigger.to_state.state == "pressbuttonpage02button04" -%} {{ nextion_colors[entity12_icon_color] | int(65535) }}
+                {%- elif trigger.to_state.state == "pressbuttonpage02button05" -%} {{ nextion_colors[entity13_icon_color] | int(65535) }}
+                {%- elif trigger.to_state.state == "pressbuttonpage02button06" -%} {{ nextion_colors[entity14_icon_color] | int(65535) }}
+                {%- elif trigger.to_state.state == "pressbuttonpage02button07" -%} {{ nextion_colors[entity15_icon_color] | int(65535) }}
+                {%- elif trigger.to_state.state == "pressbuttonpage02button08" -%} {{ nextion_colors[entity16_icon_color] | int(65535) }}
+                {%- elif trigger.to_state.state == "pressbuttonpage03button01" -%} {{ nextion_colors[entity17_icon_color] | int(65535) }}
+                {%- elif trigger.to_state.state == "pressbuttonpage03button02" -%} {{ nextion_colors[entity18_icon_color] | int(65535) }}
+                {%- elif trigger.to_state.state == "pressbuttonpage03button03" -%} {{ nextion_colors[entity19_icon_color] | int(65535) }}
+                {%- elif trigger.to_state.state == "pressbuttonpage03button04" -%} {{ nextion_colors[entity20_icon_color] | int(65535) }}
+                {%- elif trigger.to_state.state == "pressbuttonpage03button05" -%} {{ nextion_colors[entity21_icon_color] | int(65535) }}
+                {%- elif trigger.to_state.state == "pressbuttonpage03button06" -%} {{ nextion_colors[entity22_icon_color] | int(65535) }}
+                {%- elif trigger.to_state.state == "pressbuttonpage03button07" -%} {{ nextion_colors[entity23_icon_color] | int(65535) }}
+                {%- elif trigger.to_state.state == "pressbuttonpage03button08" -%} {{ nextion_colors[entity24_icon_color] | int(65535) }}
+                {%- elif trigger.to_state.state == "pressbuttonpage04button01" -%} {{ nextion_colors[entity25_icon_color] | int(65535) }}
+                {%- elif trigger.to_state.state == "pressbuttonpage04button02" -%} {{ nextion_colors[entity26_icon_color] | int(65535) }}
+                {%- elif trigger.to_state.state == "pressbuttonpage04button03" -%} {{ nextion_colors[entity27_icon_color] | int(65535) }}
+                {%- elif trigger.to_state.state == "pressbuttonpage04button04" -%} {{ nextion_colors[entity28_icon_color] | int(65535) }}
+                {%- elif trigger.to_state.state == "pressbuttonpage04button05" -%} {{ nextion_colors[entity29_icon_color] | int(65535) }}
+                {%- elif trigger.to_state.state == "pressbuttonpage04button06" -%} {{ nextion_colors[entity30_icon_color] | int(65535) }}
+                {%- elif trigger.to_state.state == "pressbuttonpage04button07" -%} {{ nextion_colors[entity31_icon_color] | int(65535) }}
+                {%- elif trigger.to_state.state == "pressbuttonpage04button08" -%} {{ nextion_colors[entity32_icon_color] | int(65535) }}
                 {%- endif -%}
 
 
@@ -9218,7 +10610,7 @@ action:
           - service: "{{ command_font_color }}"
             data:
               component: home.value01_state
-              message: "{{ home_value01_label_color }}"
+              message: "{{ nextion_colors[home_value01_label_color] | int(65535) }}"
           ### ICON Font ###
           - delay:
               milliseconds: "{{ delay_value }}"
@@ -9240,7 +10632,7 @@ action:
           - service: "{{ command_font_color }}"
             data:
               component: home.value02_state
-              message: "{{ home_value02_label_color }}"
+              message: "{{ nextion_colors[home_value02_label_color] | int(65535) }}"
           ### ICON Font ###
           - delay:
               milliseconds: "{{ delay_value }}"
@@ -9262,7 +10654,7 @@ action:
           - service: "{{ command_font_color }}"
             data:
               component: home.value03_state
-              message: "{{ home_value03_label_color }}"
+              message: "{{ nextion_colors[home_value03_label_color] | int(65535) }}"
           ### ICON Font ###
           - delay:
               milliseconds: "{{ delay_value }}"
@@ -9289,7 +10681,7 @@ action:
           - service: "{{ command_font_color }}"
             data:
               component: home.icon_top_01
-              message: "{{ relay01_icon_color }}"
+              message: "{{ nextion_colors[relay01_icon_color] | int(65535) }}"
           ### ICON Font ###
           - delay:
               milliseconds: "{{ delay_value }}"
@@ -9316,7 +10708,7 @@ action:
           - service: "{{ command_font_color }}"
             data:
               component: home.icon_top_02
-              message: "{{ relay02_icon_color }}"
+              message: "{{ nextion_colors[relay02_icon_color] | int(65535) }}"
           ### ICON Font ###
           - delay:
               milliseconds: "{{ delay_value }}"
@@ -9344,7 +10736,7 @@ action:
           - service: "{{ command_font_color }}"
             data:
               component: home.icon_top_03
-              message: "{{ thermostat_icon_color }}"
+              message: "{{ nextion_colors[thermostat_icon_color] | int(65535) }}"
           ### ICON Font ###
           - delay:
               milliseconds: "{{ delay_value }}"
@@ -9371,7 +10763,7 @@ action:
           - service: "{{ command_font_color }}"
             data:
               component: home.icon_top_04
-              message: "{{ chip01_icon_color }}"
+              message: "{{ nextion_colors[chip01_icon_color] | int(65535) }}"
           ### ICON Font ###
           - delay:
               milliseconds: "{{ delay_value }}"
@@ -9398,7 +10790,7 @@ action:
           - service: "{{ command_font_color }}"
             data:
               component: home.icon_top_05
-              message: "{{ chip02_icon_color }}"
+              message: "{{ nextion_colors[chip02_icon_color] | int(65535) }}"
           ### ICON Font ###
           - delay:
               milliseconds: "{{ delay_value }}"
@@ -9425,7 +10817,7 @@ action:
           - service: "{{ command_font_color }}"
             data:
               component: home.icon_top_06
-              message: "{{ chip03_icon_color }}"
+              message: "{{ nextion_colors[chip03_icon_color] | int(65535) }}"
           ### ICON Font ###
           - delay:
               milliseconds: "{{ delay_value }}"
@@ -9452,7 +10844,7 @@ action:
           - service: "{{ command_font_color }}"
             data:
               component: home.icon_top_07
-              message: "{{ chip04_icon_color }}"
+              message: "{{ nextion_colors[chip04_icon_color] | int(65535) }}"
           ### ICON Font ###
           - delay:
               milliseconds: "{{ delay_value }}"
@@ -9479,7 +10871,7 @@ action:
           - service: "{{ command_font_color }}"
             data:
               component: home.icon_top_08
-              message: "{{ chip05_icon_color }}"
+              message: "{{ nextion_colors[chip05_icon_color] | int(65535) }}"
           ### ICON Font ###
           - delay:
               milliseconds: "{{ delay_value }}"
@@ -9506,7 +10898,7 @@ action:
           - service: "{{ command_font_color }}"
             data:
               component: home.icon_top_09
-              message: "{{ chip06_icon_color }}"
+              message: "{{ nextion_colors[chip06_icon_color] | int(65535) }}"
           ### ICON Font ###
           - delay:
               milliseconds: "{{ delay_value }}"
@@ -9533,7 +10925,7 @@ action:
           - service: "{{ command_font_color }}"
             data:
               component: home.icon_top_10
-              message: "{{ chip07_icon_color }}"
+              message: "{{ nextion_colors[chip07_icon_color] | int(65535) }}"
           ### ICON Font ###
           - delay:
               milliseconds: "{{ delay_value }}"
@@ -9844,7 +11236,7 @@ action:
           - service: "{{ command_font_color }}"
             data:
               component: home.time
-              message: "{{ time_label_color }}"
+              message: "{{ nextion_colors[time_label_color] | int(65535) }}"
           ### TIME Font ###
           - service: "{{ command_text_printf }}"
             data:
@@ -9856,7 +11248,7 @@ action:
           - service: "{{ command_font_color }}"
             data:
               component: home.date
-              message: "{{ date_label_color }}"
+              message: "{{ nextion_colors[date_label_color] | int(65535) }}"
           ### DATE Font ###
           - delay:
               milliseconds: "{{ delay_value }}"
@@ -9878,7 +11270,7 @@ action:
           - service: "{{ command_font_color }}"
             data:
               component: home.outdoor_temp
-              message: "{{ home_outdoor_temp_label_color }}"
+              message: "{{ nextion_colors[home_outdoor_temp_label_color] | int(65535) }}"
           ### LABEL Outdoor Temp Font ###
           - delay:
               milliseconds: "{{ delay_value }}"
@@ -9900,7 +11292,7 @@ action:
           - service: "{{ command_font_color }}"
             data:
               component: home.current_temp
-              message: "{{ home_indoor_temp_label_color }}"
+              message: "{{ nextion_colors[home_indoor_temp_label_color] | int(65535) }}"
           ### LABEL Indoor Temp Font ###
           - delay:
               milliseconds: "{{ delay_value }}"
@@ -9926,7 +11318,7 @@ action:
               - service: "{{ command_font_color }}"
                 data:
                   component: home.current_temp
-                  message: "{{ home_indoor_temp_label_color }}"
+                  message: "{{ nextion_colors[home_indoor_temp_label_color] | int(65535) }}"
               ### LABEL Indoor Temp Font ###
               - delay:
                   milliseconds: "{{ delay_value }}"
@@ -9952,7 +11344,7 @@ action:
               - service: "{{ command_font_color }}"
                 data:
                   component: home.outdoor_temp
-                  message: "{{ home_outdoor_temp_label_color }}"
+                  message: "{{ nextion_colors[home_outdoor_temp_label_color] | int(65535) }}"
               ### LABEL Outdoor Temp Font ###
               - delay:
                   milliseconds: "{{ delay_value }}"


### PR DESCRIPTION
Replacing color_xx by nextion_colors.color_name in order to make easier to implement color selection by name instead of rgb565 decimal code. And also makes easier to read the code... ;)

Users will be able to select the colors by name in a drop down instead of typing a color code in rgb565 (which is not very popular).
The following colors are available for now:
  nextion_colors: ## Nextion docs: https://nextion.tech/instruction-set/ (item 5 - Color code constants)
    black: 0
    blue: 1055
    brown: 48192
    gray: 33840
    graydark: 10597
    graylight: 33808
    graysuperlight: 52857
    green: 2016
    red: 63488
    white: 65535
    yellow: 65472

There are spaces for improvement in the code, but I will wait for some feedback first.