### PR TITLE
Added support to css color names

### DIFF
--- a/nspanel_blueprint.yaml
+++ b/nspanel_blueprint.yaml
@@ -165,9 +165,306 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
     home_outdoor_temp_label_color:
       name: Outdoor Temperature Sensor - LABEL COLOR (Optional)
       description: '* *Page "HOME" - Label color which should be displayed*'
-      default: 65535 #White
-      selector:
-        text: {}
+      default: "65535" # white
+      selector: &color-selector
+        select: 
+          multiple: false
+          options: # https://www.w3.org/wiki/CSS/Properties/color/keywords
+            - label: aliceblue
+              value: "63455"
+            - label: antiquewhite
+              value: "65370"
+            - label: aqua
+              value: "2047"
+            - label: aquamarine
+              value: "32762"
+            - label: azure
+              value: "63487"
+            - label: beige
+              value: "63419"
+            - label: bisque
+              value: "65336"
+            - label: Black
+              value: "0"
+            - label: blanchedalmond
+              value: "65369"
+            - label: blue
+              value: "31"
+            - label: Blue (Nextion)
+              value: "1055"
+            - label: blueviolet
+              value: "35164"
+            - label: brown
+              value: "41285"
+            - label: Brown (Nextion)
+              value: "48192"
+            - label: burlywood
+              value: "56784"
+            - label: cadetblue
+              value: "23796"
+            - label: chartreuse
+              value: "32736"
+            - label: chocolate
+              value: "54083"
+            - label: coral
+              value: "64490"
+            - label: cornflowerblue
+              value: "25789"
+            - label: cornsilk
+              value: "65499"
+            - label: cyan
+              value: "2048"
+            - label: darkblue
+              value: "17"
+            - label: darkcyan
+              value: "1105"
+            - label: darkgoldenrod
+              value: "48161"
+            - label: darkgreen
+              value: "800"
+            - label: darkgrey
+              value: "44373"
+            - label: darkkhaki
+              value: "48557"
+            - label: darkmagenta
+              value: "34833"
+            - label: darkolivegreen
+              value: "21317"
+            - label: darkorange
+              value: "64608"
+            - label: darkorchid
+              value: "39321"
+            - label: darkred
+              value: "34816"
+            - label: darksalmon
+              value: "60591"
+            - label: darkseagreen
+              value: "36337"
+            - label: darkslateblue
+              value: "18929"
+            - label: darkslategray
+              value: "10857"
+            - label: darkturquoise
+              value: "1658"
+            - label: darkviolet
+              value: "36890"
+            - label: deeppink
+              value: "63666"
+            - label: deepskyblue
+              value: "1535"
+            - label: dimgray
+              value: "27469"
+            - label: dodgerblue
+              value: "7327"
+            - label: firebrick
+              value: "45316"
+            - label: floralwhite
+              value: "65502"
+            - label: forestgreen
+              value: "9284"
+            - label: fuchsia
+              value: "63519"
+            - label: gainsboro
+              value: "57083"
+            - label: gold
+              value: "65184"
+            - label: goldenrod
+              value: "56612"
+            - label: ghostwhite
+              value: "65503"
+            - label: grey
+              value: "33808"
+            - label: Grey (Nextion)
+              value: "33840"
+            - label: Grey - Dark (Nextion)
+              value: "10597"
+            - label: Grey - Light (Nextion)
+              value: "33808"
+            - label: Grey - Super light (Nextion)
+              value: "52857"
+            - label: green
+              value: "1024"
+            - label: Green (Nextion)
+              value: "2016"
+            - label: greenyellow
+              value: "45029"
+            - label: honeydew
+              value: "63486"
+            - label: hotpink
+              value: "64342"
+            - label: indianred
+              value: "51947"
+            - label: indigo
+              value: "18448"
+            - label: ivory
+              value: "65534"
+            - label: khaki
+              value: "63281"
+            - label: lavender
+              value: "59199"
+            - label: lavenderblush
+              value: "65438"
+            - label: lawngreen
+              value: "32737"
+            - label: lemonchiffon
+              value: "65497"
+            - label: lightblue
+              value: "44764"
+            - label: lightcoral
+              value: "62480"
+            - label: lightcyan
+              value: "59391"
+            - label: lightgoldenrodyellow
+              value: "65498"
+            - label: lightgreen
+              value: "38770"
+            - label: lightgrey
+              value: "54938"
+            - label: lightpink
+              value: "64952"
+            - label: lightsalmon
+              value: "64783"
+            - label: lightseagreen
+              value: "9621"
+            - label: lightslategray
+              value: "29779"
+            - label: lightskyblue
+              value: "34431"
+            - label: lightsteelblue
+              value: "46651"
+            - label: lightyellow
+              value: "65532"
+            - label: lime
+              value: "2016"
+            - label: limegreen
+              value: "13926"
+            - label: linen
+              value: "65436"
+            - label: magenta
+              value: "63520"
+            - label: maroon
+              value: "32768"
+            - label: mediumaquamarine
+              value: "26229"
+            - label: mediumblue
+              value: "25"
+            - label: mediumorchid
+              value: "47802"
+            - label: mediumpurple
+              value: "37787"
+            - label: mediumseagreen
+              value: "15758"
+            - label: mediumslateblue
+              value: "31581"
+            - label: mediumspringgreen
+              value: "2003"
+            - label: mediumturquoise
+              value: "20121"
+            - label: mediumvioletred
+              value: "49328"
+            - label: midnightblue
+              value: "6350"
+            - label: mintcream
+              value: "63488"
+            - label: mistyrose
+              value: "65340"
+            - label: moccasin
+              value: "65334"
+            - label: navajowhite
+              value: "65269"
+            - label: navy
+              value: "16"
+            - label: oldlace
+              value: "65468"
+            - label: olive
+              value: "33792"
+            - label: olivedrab
+              value: "27748"
+            - label: orange
+              value: "64800"
+            - label: orangered
+              value: "64032"
+            - label: orchid
+              value: "56218"
+            - label: palegoldenrod
+              value: "61269"
+            - label: palegreen
+              value: "40915"
+            - label: paleturquoise
+              value: "44925"
+            - label: palevioletred
+              value: "56210"
+            - label: papayawhip
+              value: "65402"
+            - label: peachpuff
+              value: "65239"
+            - label: peru
+              value: "52263"
+            - label: pink
+              value: "65049"
+            - label: plum
+              value: "56603"
+            - label: powderblue
+              value: "46876"
+            - label: purple
+              value: "32784"
+            - label: Red
+              value: "63488"
+            - label: rosybrown
+              value: "48241"
+            - label: royalblue
+              value: "17244"
+            - label: saddlebrown
+              value: "35362"
+            - label: salmon
+              value: "64526"
+            - label: sandybrown
+              value: "62764"
+            - label: seagreen
+              value: "11338"
+            - label: seashell
+              value: "65469"
+            - label: sienna
+              value: "41605"
+            - label: silver
+              value: "50712"
+            - label: skyblue
+              value: "34429"
+            - label: slateblue
+              value: "27353"
+            - label: slategray
+              value: "29714"
+            - label: snow
+              value: "65504"
+            - label: springgreen
+              value: "2031"
+            - label: steelblue
+              value: "17430"
+            - label: tan
+              value: "54705"
+            - label: teal
+              value: "1040"
+            - label: thistle
+              value: "56827"
+            - label: tomato
+              value: "64264"
+            - label: turquoise
+              value: "18202"
+            - label: violet
+              value: "60445"
+            - label: wheat
+              value: "63222"
+            - label: White
+              value: "65535"
+            - label: whitesmoke
+              value: "63422"
+            - label: yellow
+              value: "65504"
+            - label: Yellow (Nextion)
+              value: "65472"
+            - label: yellowgreen
+              value: "40550"
+
     indoortemp:
       name: Indoor Temperature Sensor - ENTITY (Optional)
       description: '* *Page "HOME" - An indoor temperature sensor is not necessary. Leave the field empty if you want to use the temperature sensor of the NSPanel. Additionally a temperature correction for the NSPanel sensor is possible under HA Devices. So everyone can adjust the sensor exactly*'
@@ -185,15 +482,13 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
     home_indoor_temp_icon_color:
       name: Indoor Temperature Sensor - ICON COLOR (Optional)
       description: '* *Page "HOME" - Icon color which should be displayed*'
-      default: 65535 #White
-      selector:
-        text: {}
+      default: "65535" # white
+      selector: *color-selector
     home_indoor_temp_label_color:
       name: Indoor Temperature Sensor - LABEL COLOR (Optional)
       description: '* *Page "HOME" - Label color which should be displayed*'
-      default: 65535 #White
-      selector:
-        text: {}
+      default: "65535" # white
+      selector: *color-selector
 
     ##### PLACEHOLDER ######################################################################
     placeholder02:
@@ -224,15 +519,13 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
     home_value01_icon_color:
       name: Sensor 01 - ICON COLOR (Optional)
       description: '* *Page "HOME" - Icon color which should be displayed*'
-      default: 52857 #Grey super light
-      selector:
-        text: {}
+      default: "52857" # graysuperlight
+      selector: *color-selector
     home_value01_label_color:
       name: Sensor 01 - LABEL COLOR (Optional)
       description: '* *Page "HOME" - Label color which should be displayed*'
-      default: 52857 #Grey super light
-      selector:
-        text: {}
+      default: "52857" # graysuperlight
+      selector: *color-selector
     home_value02:
       name: Sensor 02 - ENTITY (Optional)
       description: '* *Page "HOME" - Entity which should be displayed*'
@@ -250,15 +543,13 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
     home_value02_icon_color:
       name: Sensor 02 - ICON COLOR (Optional)
       description: '* *Page "HOME" - Icon color which should be displayed*'
-      default: 52857 #Grey super light
-      selector:
-        text: {}
+      default: "52857" # graysuperlight
+      selector: *color-selector
     home_value02_label_color:
       name: Sensor 02 - LABEL COLOR (Optional)
       description: '* *Page "HOME" - Label color which should be displayed*'
-      default: 52857 #Grey super light
-      selector:
-        text: {}
+      default: "52857" # graysuperlight
+      selector: *color-selector
     home_value03:
       name: Sensor 03 - ENTITY (Optional)
       description: '* *Page "HOME" - Entity which should be displayed*'
@@ -276,15 +567,13 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
     home_value03_icon_color:
       name: Sensor 03 - ICON COLOR (Optional)
       description: '* *Page "HOME" - Icon color which should be displayed*'
-      default: 52857 #Grey super light
-      selector:
-        text: {}
+      default: "52857" # graysuperlight
+      selector: *color-selector
     home_value03_label_color:
       name: Sensor 03 - LABEL COLOR (Optional)
       description: '* *Page "HOME" - Label color which should be displayed*'
-      default: 52857 #Grey super light
-      selector:
-        text: {}
+      default: "52857" # graysuperlight
+      selector: *color-selector
 
     ##### PLACEHOLDER ######################################################################
     placeholder03:
@@ -318,9 +607,8 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
     chip01_icon_color:
       name: Chip 01 - ICON COLOR (Optional)
       description: '* *Page "HOME" - Icon color which should be displayed*'
-      default: 33808 #Grey light
-      selector:
-        text: {}
+      default: "33808" # graylight
+      selector: *color-selector
     chip02:
       name: Chip 02 - ENTITY (Optional)
       description: '* *Page "HOME" - Entity which should be displayed (ONLY light | switch | binary_sensor | sensor | with state ON/OFF)*'
@@ -341,9 +629,8 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
     chip02_icon_color:
       name: Chip 02 - ICON COLOR (Optional)
       description: '* *Page "HOME" - Icon color which should be displayed*'
-      default: 33808 #Grey light
-      selector:
-        text: {}
+      default: "33808" # graylight
+      selector: *color-selector
     chip03:
       name: Chip 03 - ENTITY (Optional)
       description: '* *Page "HOME" - Entity which should be displayed (ONLY light | switch | binary_sensor | sensor | with state ON/OFF)*'
@@ -364,9 +651,8 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
     chip03_icon_color:
       name: Chip 03 - ICON COLOR (Optional)
       description: '* *Page "HOME" - Icon color which should be displayed*'
-      default: 33808 #Grey light
-      selector:
-        text: {}
+      default: "33808" # graylight
+      selector: *color-selector
     chip04:
       name: Chip 04 - ENTITY (Optional)
       description: '* *Page "HOME" - Entity which should be displayed (ONLY light | switch | binary_sensor | sensor | with state ON/OFF)*'
@@ -387,9 +673,8 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
     chip04_icon_color:
       name: Chip 04 - ICON COLOR (Optional)
       description: '* *Page "HOME" - Icon color which should be displayed*'
-      default: 33808 #Grey light
-      selector:
-        text: {}
+      default: "33808" # graylight
+      selector: *color-selector
     chip05:
       name: Chip 05 - ENTITY (Optional)
       description: '* *Page "HOME" - Entity which should be displayed (ONLY light | switch | binary_sensor | sensor | with state ON/OFF)*'
@@ -410,9 +695,8 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
     chip05_icon_color:
       name: Chip 05 - ICON COLOR (Optional)
       description: '* *Page "HOME" - Icon color which should be displayed*'
-      default: 33808 #Grey light
-      selector:
-        text: {}
+      default: "33808" # graylight
+      selector: *color-selector
     chip06:
       name: Chip 06 - ENTITY (Optional)
       description: '* *Page "HOME" - Entity which should be displayed (ONLY light | switch | binary_sensor | sensor | with state ON/OFF)*'
@@ -433,9 +717,8 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
     chip06_icon_color:
       name: Chip 06 - ICON COLOR (Optional)
       description: '* *Page "HOME" - Icon color which should be displayed*'
-      default: 33808 #Grey light
-      selector:
-        text: {}
+      default: "33808" # graylight
+      selector: *color-selector
     chip07:
       name: Chip 07 - ENTITY (Optional)
       description: '* *Page "HOME" - Entity which should be displayed (ONLY light | switch | binary_sensor | sensor | with state ON/OFF)*'
@@ -456,9 +739,8 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
     chip07_icon_color:
       name: Chip 07 - ICON COLOR (Optional)
       description: '* *Page "HOME" - Icon color which should be displayed*'
-      default: 33808 #Grey light
-      selector:
-        text: {}
+      default: "33808" # graylight
+      selector: *color-selector
 
     ##### PLACEHOLDER ######################################################################
     placeholder04:
@@ -536,9 +818,8 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
     home_button05_icon_color:
       name: QR Code - ICON COLOR (Optional)
       description: '* *Page "HOME" - Icon color which should be displayed (default color is set)*'
-      default: 52857 #Grey super light
-      selector:
-        text: {}
+      default: "52857" # graysuperlight
+      selector: *color-selector
 
     ##### PLACEHOLDER ######################################################################
     placeholder06:
@@ -609,9 +890,8 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
     left_button_color:
       name: Left hardware button - LABEL COLOR (Optional)
       description: '* *Page "HOME" - LABEL color which should be displayed*'
-      default: 52857 #Grey super light
-      selector:
-        text: {}
+      default: "52857" # graysuperlight
+      selector: *color-selector
 
     relay_2_local_fallback:
       name: Activate relay 2 local fallback - TRUE/FALSE (Optional)
@@ -660,9 +940,8 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
     right_button_color:
       name: Right hardware button - LABEL COLOR (Optional)
       description: '* *Page "HOME" - LABEL color which should be displayed*'
-      default: 52857 #Grey super light
-      selector:
-        text: {}
+      default: "52857" # graysuperlight
+      selector: *color-selector
 
     ##### PLACEHOLDER ######################################################################
     placeholder07:
@@ -740,9 +1019,8 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
     entity01_icon_color:
       name: Button 01 - ICON COLOR (Optional)
       description: '* *Page "BUTTONPAGE01" - Icon color which should be displayed when button is on*'
-      default: 1055 #Blue
-      selector:
-        text: {}
+      default: "1055" # blue
+      selector: *color-selector
     entity01_confirm:
       name: Confirm execution of the button press - TRUE/FALSE (Optional)
       default: false
@@ -784,9 +1062,8 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
     entity02_icon_color:
       name: Button 02 - ICON COLOR (Optional)
       description: '* *Page "BUTTONPAGE01" - Icon color which should be displayed when button is on*'
-      default: 1055 #Blue
-      selector:
-        text: {}
+      default: "1055" # blue
+      selector: *color-selector
     entity02_confirm:
       name: Confirm execution of the button press - TRUE/FALSE (Optional)
       default: false
@@ -828,9 +1105,8 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
     entity03_icon_color:
       name: Button 03 - ICON COLOR (Optional)
       description: '* *Page "BUTTONPAGE01" - Icon color which should be displayed when button is on*'
-      default: 1055 #Blue
-      selector:
-        text: {}
+      default: "1055" # blue
+      selector: *color-selector
     entity03_confirm:
       name: Confirm execution of the button press - TRUE/FALSE (Optional)
       default: false
@@ -873,8 +1149,7 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
       name: Button 04 - ICON COLOR (Optional)
       description: '* *Page "BUTTONPAGE01" - Icon color which should be displayed when button is on*'
       default: 1055 #Blue
-      selector:
-        text: {}
+      selector: *color-selector
     entity04_confirm:
       name: Confirm execution of the button press - TRUE/FALSE (Optional)
       default: false
@@ -916,9 +1191,8 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
     entity05_icon_color:
       name: Button 05 - ICON COLOR (Optional)
       description: '* *Page "BUTTONPAGE01" - Icon color which should be displayed when button is on*'
-      default: 1055 #Blue
-      selector:
-        text: {}
+      default: "1055" # blue
+      selector: *color-selector
     entity05_confirm:
       name: Confirm execution of the button press - TRUE/FALSE (Optional)
       default: false
@@ -960,9 +1234,8 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
     entity06_icon_color:
       name: Button 06 - ICON COLOR (Optional)
       description: '* *Page "BUTTONPAGE01" - Icon color which should be displayed when button is on*'
-      default: 1055 #Blue
-      selector:
-        text: {}
+      default: "1055" # blue
+      selector: *color-selector
     entity06_confirm:
       name: Confirm execution of the button press - TRUE/FALSE (Optional)
       default: false
@@ -1004,9 +1277,8 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
     entity07_icon_color:
       name: Button 07 - ICON COLOR (Optional)
       description: '* *Page "BUTTONPAGE01" - Icon color which should be displayed when button is on*'
-      default: 1055 #Blue
-      selector:
-        text: {}
+      default: "1055" # blue
+      selector: *color-selector
     entity07_confirm:
       name: Confirm execution of the button press - TRUE/FALSE (Optional)
       default: false
@@ -1048,9 +1320,8 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
     entity08_icon_color:
       name: Button 08 - ICON COLOR (Optional)
       description: '* *Page "BUTTONPAGE01" - Icon color which should be displayed when button is on*'
-      default: 1055 #Blue
-      selector:
-        text: {}
+      default: "1055" # blue
+      selector: *color-selector
     entity08_confirm:
       name: Confirm execution of the button press - TRUE/FALSE (Optional)
       default: false
@@ -1102,9 +1373,8 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
     entity09_icon_color:
       name: Button 09 - ICON COLOR (Optional)
       description: '* *Page "BUTTONPAGE02" - Icon color which should be displayed when button is on*'
-      default: 1055 #Blue
-      selector:
-        text: {}
+      default: "1055" # blue
+      selector: *color-selector
     entity09_confirm:
       name: Confirm execution of the button press - TRUE/FALSE (Optional)
       default: false
@@ -1146,9 +1416,8 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
     entity10_icon_color:
       name: Button 10 - ICON COLOR (Optional)
       description: '* *Page "BUTTONPAGE02" - Icon color which should be displayed when button is on*'
-      default: 1055 #Blue
-      selector:
-        text: {}
+      default: "1055" # blue
+      selector: *color-selector
     entity10_confirm:
       name: Confirm execution of the button press - TRUE/FALSE (Optional)
       default: false
@@ -1190,9 +1459,8 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
     entity11_icon_color:
       name: Button 11 - ICON COLOR (Optional)
       description: '* *Page "BUTTONPAGE02" - Icon color which should be displayed when button is on*'
-      default: 1055 #Blue
-      selector:
-        text: {}
+      default: "1055" # blue
+      selector: *color-selector
     entity11_confirm:
       name: Confirm execution of the button press - TRUE/FALSE (Optional)
       default: false
@@ -1234,9 +1502,8 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
     entity12_icon_color:
       name: Button 12 - ICON COLOR (Optional)
       description: '* *Page "BUTTONPAGE02" - Icon color which should be displayed when button is on*'
-      default: 1055 #Blue
-      selector:
-        text: {}
+      default: "1055" # blue
+      selector: *color-selector
     entity12_confirm:
       name: Confirm execution of the button press - TRUE/FALSE (Optional)
       default: false
@@ -1278,9 +1545,8 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
     entity13_icon_color:
       name: Button 13 - ICON COLOR (Optional)
       description: '* *Page "BUTTONPAGE02" - Icon color which should be displayed when button is on*'
-      default: 1055 #Blue
-      selector:
-        text: {}
+      default: "1055" # blue
+      selector: *color-selector
     entity13_confirm:
       name: Confirm execution of the button press - TRUE/FALSE (Optional)
       default: false
@@ -1322,9 +1588,8 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
     entity14_icon_color:
       name: Button 14 - ICON COLOR (Optional)
       description: '* *Page "BUTTONPAGE02" - Icon color which should be displayed when button is on*'
-      default: 1055 #Blue
-      selector:
-        text: {}
+      default: "1055" # blue
+      selector: *color-selector
     entity14_confirm:
       name: Confirm execution of the button press - TRUE/FALSE (Optional)
       default: false
@@ -1366,9 +1631,8 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
     entity15_icon_color:
       name: Button 15 - ICON COLOR (Optional)
       description: '* *Page "BUTTONPAGE02" - Icon color which should be displayed when button is on*'
-      default: 1055 #Blue
-      selector:
-        text: {}
+      default: "1055" # blue
+      selector: *color-selector
     entity15_confirm:
       name: Confirm execution of the button press - TRUE/FALSE (Optional)
       default: false
@@ -1410,9 +1674,8 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
     entity16_icon_color:
       name: Button 16 - ICON COLOR (Optional)
       description: '* *Page "BUTTONPAGE02" - Icon color which should be displayed when button is on*'
-      default: 1055 #Blue
-      selector:
-        text: {}
+      default: "1055" # blue
+      selector: *color-selector
     entity16_confirm:
       name: Confirm execution of the button press - TRUE/FALSE (Optional)
       default: false
@@ -1464,9 +1727,8 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
     entity17_icon_color:
       name: Button 17 - ICON COLOR (Optional)
       description: '* *Page "BUTTONPAGE03" - Icon color which should be displayed when button is on*'
-      default: 1055 #Blue
-      selector:
-        text: {}
+      default: "1055" # blue
+      selector: *color-selector
     entity17_confirm:
       name: Confirm execution of the button press - TRUE/FALSE (Optional)
       default: false
@@ -1508,9 +1770,8 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
     entity18_icon_color:
       name: Button 18 - ICON COLOR (Optional)
       description: '* *Page "BUTTONPAGE03" - Icon color which should be displayed when button is on*'
-      default: 1055 #Blue
-      selector:
-        text: {}
+      default: "1055" # blue
+      selector: *color-selector
     entity18_confirm:
       name: Confirm execution of the button press - TRUE/FALSE (Optional)
       default: false
@@ -1552,9 +1813,8 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
     entity19_icon_color:
       name: Button 19 - ICON COLOR (Optional)
       description: '* *Page "BUTTONPAGE03" - Icon color which should be displayed when button is on*'
-      default: 1055 #Blue
-      selector:
-        text: {}
+      default: "1055" # blue
+      selector: *color-selector
     entity19_confirm:
       name: Confirm execution of the button press - TRUE/FALSE (Optional)
       default: false
@@ -1596,9 +1856,8 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
     entity20_icon_color:
       name: Button 20 - ICON COLOR (Optional)
       description: '* *Page "BUTTONPAGE03" - Icon color which should be displayed when button is on*'
-      default: 1055 #Blue
-      selector:
-        text: {}
+      default: "1055" # blue
+      selector: *color-selector
     entity20_confirm:
       name: Confirm execution of the button press - TRUE/FALSE (Optional)
       default: false
@@ -1640,9 +1899,8 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
     entity21_icon_color:
       name: Button 21 - ICON COLOR (Optional)
       description: '* *Page "BUTTONPAGE03" - Icon color which should be displayed when button is on*'
-      default: 1055 #Blue
-      selector:
-        text: {}
+      default: "1055" # blue
+      selector: *color-selector
     entity21_confirm:
       name: Confirm execution of the button press - TRUE/FALSE (Optional)
       default: false
@@ -1684,9 +1942,8 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
     entity22_icon_color:
       name: Button 22 - ICON COLOR (Optional)
       description: '* *Page "BUTTONPAGE03" - Icon color which should be displayed when button is on*'
-      default: 1055 #Blue
-      selector:
-        text: {}
+      default: "1055" # blue
+      selector: *color-selector
     entity22_confirm:
       name: Confirm execution of the button press - TRUE/FALSE (Optional)
       default: false
@@ -1728,9 +1985,8 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
     entity23_icon_color:
       name: Button 23 - ICON COLOR (Optional)
       description: '* *Page "BUTTONPAGE03" - Icon color which should be displayed when button is on*'
-      default: 1055 #Blue
-      selector:
-        text: {}
+      default: "1055" # blue
+      selector: *color-selector
     entity23_confirm:
       name: Confirm execution of the button press - TRUE/FALSE (Optional)
       default: false
@@ -1772,9 +2028,8 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
     entity24_icon_color:
       name: Button 24 - ICON COLOR (Optional)
       description: '* *Page "BUTTONPAGE03" - Icon color which should be displayed when button is on*'
-      default: 1055 #Blue
-      selector:
-        text: {}
+      default: "1055" # blue
+      selector: *color-selector
     entity24_confirm:
       name: Confirm execution of the button press - TRUE/FALSE (Optional)
       default: false
@@ -1826,9 +2081,8 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
     entity25_icon_color:
       name: Button 25 - ICON COLOR (Optional)
       description: '* *Page "BUTTONPAGE04" - Icon color which should be displayed when button is on*'
-      default: 1055 #Blue
-      selector:
-        text: {}
+      default: "1055" # blue
+      selector: *color-selector
     entity25_confirm:
       name: Confirm execution of the button press - TRUE/FALSE (Optional)
       default: false
@@ -1870,9 +2124,8 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
     entity26_icon_color:
       name: Button 26 - ICON COLOR (Optional)
       description: '* *Page "BUTTONPAGE04" - Icon color which should be displayed when button is on*'
-      default: 1055 #Blue
-      selector:
-        text: {}
+      default: "1055" # blue
+      selector: *color-selector
     entity26_confirm:
       name: Confirm execution of the button press - TRUE/FALSE (Optional)
       default: false
@@ -1914,9 +2167,8 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
     entity27_icon_color:
       name: Button 27 - ICON COLOR (Optional)
       description: '* *Page "BUTTONPAGE04" - Icon color which should be displayed when button is on*'
-      default: 1055 #Blue
-      selector:
-        text: {}
+      default: "1055" # blue
+      selector: *color-selector
     entity27_confirm:
       name: Confirm execution of the button press - TRUE/FALSE (Optional)
       default: false
@@ -1958,9 +2210,8 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
     entity28_icon_color:
       name: Button 28 - ICON COLOR (Optional)
       description: '* *Page "BUTTONPAGE04" - Icon color which should be displayed when button is on*'
-      default: 1055 #Blue
-      selector:
-        text: {}
+      default: "1055" # blue
+      selector: *color-selector
     entity28_confirm:
       name: Confirm execution of the button press - TRUE/FALSE (Optional)
       default: false
@@ -2002,9 +2253,8 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
     entity29_icon_color:
       name: Button 29 - ICON COLOR (Optional)
       description: '* *Page "BUTTONPAGE04" - Icon color which should be displayed when button is on*'
-      default: 1055 #Blue
-      selector:
-        text: {}
+      default: "1055" # blue
+      selector: *color-selector
     entity29_confirm:
       name: Confirm execution of the button press - TRUE/FALSE (Optional)
       default: false
@@ -2046,9 +2296,8 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
     entity30_icon_color:
       name: Button 30 - ICON COLOR (Optional)
       description: '* *Page "BUTTONPAGE04" - Icon color which should be displayed when button is on*'
-      default: 1055 #Blue
-      selector:
-        text: {}
+      default: "1055" # blue
+      selector: *color-selector
     entity30_confirm:
       name: Confirm execution of the button press - TRUE/FALSE (Optional)
       default: false
@@ -2090,9 +2339,8 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
     entity31_icon_color:
       name: Button 31 - ICON COLOR (Optional)
       description: '* *Page "BUTTONPAGE04" - Icon color which should be displayed when button is on*'
-      default: 1055 #Blue #Blue
-      selector:
-        text: {}
+      default: "1055" # blue
+      selector: *color-selector
     entity31_confirm:
       name: Confirm execution of the button press - TRUE/FALSE (Optional)
       default: false
@@ -2134,9 +2382,8 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
     entity32_icon_color:
       name: Button 32 - ICON COLOR (Optional)
       description: '* *Page "BUTTONPAGE04" - Icon color which should be displayed when button is on*'
-      default: 1055 #Blue
-      selector:
-        text: {}
+      default: "1055" # blue
+      selector: *color-selector
     entity32_confirm:
       name: Confirm execution of the button press - TRUE/FALSE (Optional)
       default: false
@@ -2171,9 +2418,8 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
     home_button06_icon_color:
       name: Entity page - ICON COLOR (Optional)
       description: '* *Page "HOME" - Icon color which should be displayed (default color is set)*'
-      default: 52857 #Grey super light
-      selector:
-        text: {}
+      default: "52857" # graysuperlight
+      selector: *color-selector
     ##### ENTITY Page Labels #####
     ##### PLACEHOLDER ######################################################################
     placeholder12:
@@ -2839,15 +3085,13 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
     home_button04_icon_color01:
       name: Notification read - ICON COLOR (Optional)
       description: '* *Page "HOME" - Icon color which should be displayed (default color is set)*'
-      default: 52857  #Grey super light
-      selector:
-        text: {}
+      default: "52857" # graysuperlight
+      selector: *color-selector
     home_button04_icon_color02:
       name: Notification unread - ICON COLOR (Optional)
       description: '* *Page "HOME" - Icon color which should be displayed (default color is set)*'
-      default: 63488 #Red
-      selector:
-        text: {}
+      default: "63488" # red
+      selector: *color-selector
     relay01_icon:
       name: Relay 01 - ICON (Optional)
       description: '* *Page "HOME" - Icon which should be displayed (Default #E3A5) *'
@@ -2857,9 +3101,8 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
     relay01_icon_color:
       name: Relay 01 - ICON COLOR (Optional)
       description: '* *Page "HOME" - Icon color which should be displayed (default color is set)*'
-      default: 33808 #Grey light
-      selector:
-        text: {}
+      default: "33808" # graylight
+      selector: *color-selector
     relay02_icon:
       name: Relay 02 - ICON (Optional)
       description: '* *Page "HOME" - Icon which should be displayed (Default #E3A8) *'
@@ -2869,9 +3112,8 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
     relay02_icon_color:
       name: Relay - ICON COLOR (Optional)
       description: '* *Page "HOME" - Icon color which should be displayed (default color is set)*'
-      default: 33808 #Grey light
-      selector:
-        text: {}
+      default: "33808" # graylight
+      selector: *color-selector
     thermostat_icon:
       name: Thermostat - ICON (Optional)
       description: '* *Page "HOME" - Icon which should be displayed (Default #E50E) *'
@@ -2887,21 +3129,18 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
     thermostat_icon_color:
       name: Thermostat / Heat - ICON COLOR (Optional)
       description: '* *Page "HOME" - Icon color which should be displayed (default color is set)*'
-      default: 33808 #Grey light
-      selector:
-        text: {}
+      default: "33808" # graylight
+      selector: *color-selector
     time_label_color:
       name: Time - LABEL COLOR (Optional)
       description: '* *Page "HOME" - Label color which should be displayed (default color is set)*'
-      default: 65535 #White
-      selector:
-        text: {}
+      default: white
+      selector: *color-selector
     date_label_color:
       name: Date - LABEL COLOR (Optional)
       description: '* *Page "HOME" - Label color which should be displayed (default color is set)*'
-      default: 65535 #White
-      selector:
-        text: {}
+      default: white
+      selector: *color-selector
 
 ###### Muss noch Raus ###############################################################################################################################################################################
     hotwatertemp:
@@ -3107,13 +3346,25 @@ variables:
 
 ##### CHANGE ME START ##########################################################################################################
   ###### GENERAL - NEXTION COLOR MAPPING #####
-  color_01: "65535" #White
-  color_02: "10597" #Grey dark
-  color_03: "33808" #Grey light
-  color_04: "1055" #Blue
-  color_05: "63488" #Red
-  color_06: "52857" #Grey super light
-  color_07: "65472" #Yellow
+  #color_01: "65535" #White
+  #color_02: "10597" #Grey dark
+  #color_03: "33808" #Grey light
+  #color_04: "1055" #Blue
+  #color_05: "63488" #Red
+  #color_06: "52857" #Grey super light
+  #color_07: "65472" #Yellow
+  nextion_colors: ## Nextion docs: https://nextion.tech/instruction-set/ (item 5 - Color code constants)
+    black: 0
+    blue: 1055
+    brown: 48192
+    gray: 33840
+    graydark: 10597
+    graylight: 33808
+    graysuperlight: 52857
+    green: 2016
+    red: 63488
+    white: 65535
+    yellow: 65472
 
   ###### "GENERAL" NEXTION FONT ICON MAPPING #####
   blank_icon: "\U0000FFFF" #blank macbook bug
@@ -4675,7 +4926,7 @@ action:
                   - service: "{{ command_font_color }}"
                     data:
                       component: home.date
-                      message: "{{ date_label_color }}"
+                      message: "{{ date_label_color | int(65535) }}"
                   ### DATE Font ###
                   - delay:
                       milliseconds: "{{ delay_value }}"
@@ -4691,7 +4942,7 @@ action:
                   - service: "{{ command_font_color }}"
                     data:
                       component: home.time
-                      message: "{{ time_label_color }}"
+                      message: "{{ time_label_color | int(65535) }}"
                   ### TIME Font ###
                   - delay:
                       milliseconds: "{{ delay_value }}"
@@ -4713,7 +4964,7 @@ action:
                   - service: "{{ command_font_color }}"
                     data:
                       component: home.outdoor_temp
-                      message: "{{ home_outdoor_temp_label_color }}"
+                      message: "{{ home_outdoor_temp_label_color | int(65535) }}"
                   ### LABEL Outdoor Temp Font ###
                   - delay:
                       milliseconds: "{{ delay_value }}"
@@ -4734,7 +4985,7 @@ action:
                   - service: "{{ command_font_color }}"
                     data:
                       component: home.indoortempicon
-                      message: "{{ home_indoor_temp_icon_color }}"
+                      message: "{{ home_indoor_temp_icon_color | int(65535) }}"
                   ### ICON Indoor Temp Font ###
                   - delay:
                       milliseconds: "{{ delay_value }}"
@@ -4748,7 +4999,7 @@ action:
                   - service: "{{ command_font_color }}"
                     data:
                       component: home.current_temp
-                      message: "{{ home_indoor_temp_label_color }}"
+                      message: "{{ home_indoor_temp_label_color | int(65535) }}"
                   ### LABEL Indoor Temp Font ###
                   - delay:
                       milliseconds: "{{ delay_value }}"
@@ -4797,7 +5048,7 @@ action:
                       - service: "{{ command_font_color }}"
                         data:
                           component: home.left_bt_text
-                          message: "{{ left_button_color }}"
+                          message: "{{ left_button_color | int(65535) }}"
                       ### LABEL Font ###
                       - delay:
                           milliseconds: "{{ delay_value }}"
@@ -4834,7 +5085,7 @@ action:
                       - service: "{{ command_font_color }}"
                         data:
                           component: home.right_bt_text
-                          message: "{{ right_button_color }}"
+                          message: "{{ right_button_color | int(65535) }}"
                       ### LABEL Font ###
                       - delay:
                           milliseconds: "{{ delay_value }}"
@@ -4877,7 +5128,7 @@ action:
                       - service: "{{ command_font_color }}"
                         data:
                           component: home.icon_top_03
-                          message: "{{ thermostat_icon_color }}"
+                          message: "{{ thermostat_icon_color | int(65535) }}"
                       ### ICON Thermostat Font ###
                       - delay:
                           milliseconds: "{{ delay_value }}"
@@ -4902,7 +5153,7 @@ action:
                   - service: "{{ command_font_color }}"
                     data:
                       component: home.icon_top_01
-                      message: "{{ relay01_icon_color }}"
+                      message: "{{ relay01_icon_color | int(65535) }}"
                   ### ICON Relay01 Font ###
                   - delay:
                       milliseconds: "{{ delay_value }}"
@@ -4917,7 +5168,7 @@ action:
                   - service: "{{ command_font_color }}"
                     data:
                       component: home.icon_top_02
-                      message: "{{ relay02_icon_color }}"
+                      message: "{{ relay02_icon_color | int(65535) }}"
                   ### ICON Relay02 Font ###
                   - delay:
                       milliseconds: "{{ delay_value }}"
@@ -4934,31 +5185,31 @@ action:
                         - position: home.icon_top_04
                           entity: "{{ chip01 }}"
                           entity_icon: "{{ chip01_icon }}"
-                          entity_icon_color: "{{ chip01_icon_color }}"
+                          entity_icon_color: "{{ chip01_icon_color | int(65535) }}"
                         - position: home.icon_top_05
                           entity: "{{ chip02 }}"
                           entity_icon: "{{ chip02_icon }}"
-                          entity_icon_color: "{{ chip02_icon_color }}"
+                          entity_icon_color: "{{ chip02_icon_color | int(65535) }}"
                         - position: home.icon_top_06
                           entity: "{{ chip03 }}"
                           entity_icon: "{{ chip03_icon }}"
-                          entity_icon_color: "{{ chip03_icon_color }}"
+                          entity_icon_color: "{{ chip03_icon_color | int(65535) }}"
                         - position: home.icon_top_07
                           entity: "{{ chip04 }}"
                           entity_icon: "{{ chip04_icon }}"
-                          entity_icon_color: "{{ chip04_icon_color }}"
+                          entity_icon_color: "{{ chip04_icon_color | int(65535) }}"
                         - position: home.icon_top_08
                           entity: "{{ chip05 }}"
                           entity_icon: "{{ chip05_icon }}"
-                          entity_icon_color: "{{ chip05_icon_color }}"
+                          entity_icon_color: "{{ chip05_icon_color | int(65535) }}"
                         - position: home.icon_top_09
                           entity: "{{ chip06 }}"
                           entity_icon: "{{ chip06_icon }}"
-                          entity_icon_color: "{{ chip06_icon_color }}"
+                          entity_icon_color: "{{ chip06_icon_color | int(65535) }}"
                         - position: home.icon_top_10
                           entity: "{{ chip07 }}"
                           entity_icon: "{{ chip07_icon }}"
-                          entity_icon_color: "{{ chip07_icon_color }}"
+                          entity_icon_color: "{{ chip07_icon_color | int(65535) }}"
                       sequence:
                         - if:
                             - condition: template
@@ -4990,18 +5241,18 @@ action:
                         - row: home.value01
                           entity: "{{ home_value01 }}"
                           entity_icon: "{{ home_value01_icon }}"
-                          entity_icon_color: "{{ home_value01_icon_color }}"
-                          entity_label_color: "{{ home_value01_label_color }}"
+                          entity_icon_color: "{{ home_value01_icon_color | int(65535) }}"
+                          entity_label_color: "{{ home_value01_label_color | int(65535) }}"
                         - row: home.value02
                           entity: "{{ home_value02 }}"
                           entity_icon: "{{ home_value02_icon }}"
-                          entity_icon_color: "{{ home_value02_icon_color }}"
-                          entity_label_color: "{{ home_value02_label_color }}"
+                          entity_icon_color: "{{ home_value02_icon_color | int(65535) }}"
+                          entity_label_color: "{{ home_value02_label_color | int(65535) }}"
                         - row: home.value03
                           entity: "{{ home_value03 }}"
                           entity_icon: "{{ home_value03_icon }}"
-                          entity_icon_color: "{{ home_value03_icon_color }}"
-                          entity_label_color: "{{ home_value03_label_color }}"
+                          entity_icon_color: "{{ home_value03_icon_color | int(65535) }}"
+                          entity_label_color: "{{ home_value03_label_color | int(65535) }}"
                       sequence:
                         - if:
                             - condition: template
@@ -5050,7 +5301,7 @@ action:
                       set_button04_icon_font: >-
                         {%- if is_state(notification_unread, 'on') and states(notification_text) |length > 0 -%} {{ home_button04_icon_color01 }}
                         {%- elif is_state(notification_unread, 'off') and states(notification_text) |length > 0 -%} {{ home_button04_icon_color02 }}
-                        {%- else -%} {{ color_03 }}
+                        {%- else -%} {{ nextion_colors.graylight }}
                         {%- endif -%}
                   ##### SET ICON Font - Notify #####
                   - delay:
@@ -5079,7 +5330,7 @@ action:
                       - service: "{{ command_font_color }}"
                         data:
                           component: home.button05_icon
-                          message: "{{ home_button05_icon_color }}"
+                          message: "{{ home_button05_icon_color | int(65535) }}"
                       ### ICON Font ###
                       - delay:
                           milliseconds: "{{ delay_value }}"
@@ -5100,7 +5351,7 @@ action:
                       - service: "{{ command_font_color }}"
                         data:
                           component: home.button06_icon
-                          message: "{{ home_button06_icon_color }}"
+                          message: "{{ home_button06_icon_color | int(65535) }}"
                       ### ICON Font ###
                       - delay:
                           milliseconds: "{{ delay_value }}"
@@ -5140,42 +5391,42 @@ action:
                         - entity: "{{ entity01 }}"
                           button_icon: "{{ entity01_icon }}"
                           button_label: "{{ entity01_name }}"
-                          button_icon_color: "{{ entity01_icon_color }}"
+                          button_icon_color: "{{ entity01_icon_color | int(65535) }}"
                           button: buttonpage01.button01
                         - entity: "{{ entity02 }}"
                           button_icon: "{{ entity02_icon }}"
                           button_label: "{{ entity02_name }}"
-                          button_icon_color: "{{ entity02_icon_color }}"
+                          button_icon_color: "{{ entity02_icon_color | int(65535) }}"
                           button: buttonpage01.button02
                         - entity: "{{ entity03 }}"
                           button_icon: "{{ entity03_icon }}"
                           button_label: "{{ entity03_name }}"
-                          button_icon_color: "{{ entity03_icon_color }}"
+                          button_icon_color: "{{ entity03_icon_color | int(65535) }}"
                           button: buttonpage01.button03
                         - entity: "{{ entity04 }}"
                           button_icon: "{{ entity04_icon }}"
                           button_label: "{{ entity04_name }}"
-                          button_icon_color: "{{ entity04_icon_color }}"
+                          button_icon_color: "{{ entity04_icon_color | int(65535) }}"
                           button: buttonpage01.button04
                         - entity: "{{ entity05 }}"
                           button_icon: "{{ entity05_icon }}"
                           button_label: "{{ entity05_name }}"
-                          button_icon_color: "{{ entity05_icon_color }}"
+                          button_icon_color: "{{ entity05_icon_color | int(65535) }}"
                           button: buttonpage01.button05
                         - entity: "{{ entity06 }}"
                           button_icon: "{{ entity06_icon }}"
                           button_label: "{{ entity06_name }}"
-                          button_icon_color: "{{ entity06_icon_color }}"
+                          button_icon_color: "{{ entity06_icon_color | int(65535) }}"
                           button: buttonpage01.button06
                         - entity: "{{ entity07 }}"
                           button_icon: "{{ entity07_icon }}"
                           button_label: "{{ entity07_name }}"
-                          button_icon_color: "{{ entity07_icon_color }}"
+                          button_icon_color: "{{ entity07_icon_color | int(65535) }}"
                           button: buttonpage01.button07
                         - entity: "{{ entity08 }}"
                           button_icon: "{{ entity08_icon }}"
                           button_label: "{{ entity08_name }}"
-                          button_icon_color: "{{ entity08_icon_color }}"
+                          button_icon_color: "{{ entity08_icon_color | int(65535) }}"
                           button: buttonpage01.button08
                       sequence:
                         - if:
@@ -5214,39 +5465,39 @@ action:
                                   {%- endif -%}
                                 # TEXT, BRIGHTNESS and ICON Background
                                 btn_bg: >-
-                                  {%- if current_entity_state == 'unknown' or current_entity_state == 'unavailable' -%} {{ color_02 }}
-                                  {%- elif repeat.item.entity is match "button." or repeat.item.entity is match "input_button." or repeat.item.entity is match "scene." -%} {{ color_02 }}
-                                  {%- elif current_entity_state == 'on' or current_entity_state == 'open' -%} {{ color_01 }}
-                                  {%- elif current_entity_state == 'off' or current_entity_state == 'closed' -%} {{ color_02 }}
-                                  {%- elif repeat.item.entity is match "person." and current_entity_state == 'home' -%} {{ color_01 }}
-                                  {%- elif repeat.item.entity is match "person." and current_entity_state != 'home' -%} {{ color_02 }}
-                                  {%- elif repeat.item.entity is match "climate." and current_entity_state != 'off' -%} {{ color_01 }}
-                                  {%- elif repeat.item.entity is match "climate." and current_entity_state == 'off' -%} {{ color_02 }}
+                                  {%- if current_entity_state == 'unknown' or current_entity_state == 'unavailable' -%} {{ nextion_colors.graydark }}
+                                  {%- elif repeat.item.entity is match "button." or repeat.item.entity is match "input_button." or repeat.item.entity is match "scene." -%} {{ nextion_colors.graydark }}
+                                  {%- elif current_entity_state == 'on' or current_entity_state == 'open' -%} {{ nextion_colors.white }}
+                                  {%- elif current_entity_state == 'off' or current_entity_state == 'closed' -%} {{ nextion_colors.graydark }}
+                                  {%- elif repeat.item.entity is match "person." and current_entity_state == 'home' -%} {{ nextion_colors.white }}
+                                  {%- elif repeat.item.entity is match "person." and current_entity_state != 'home' -%} {{ nextion_colors.graydark }}
+                                  {%- elif repeat.item.entity is match "climate." and current_entity_state != 'off' -%} {{ nextion_colors.white }}
+                                  {%- elif repeat.item.entity is match "climate." and current_entity_state == 'off' -%} {{ nextion_colors.graydark }}
                                   {%- endif -%}
                                 # ICON Font Color
                                 btn_icon_font: >-
-                                  {%- if current_entity_state == 'unknown' or current_entity_state == 'unavailable' -%} {{ color_05 }}
-                                  {%- elif repeat.item.entity is match "button." or repeat.item.entity is match "input_button." or repeat.item.entity is match "scene." -%} {{ color_03 }}
+                                  {%- if current_entity_state == 'unknown' or current_entity_state == 'unavailable' -%} {{ nextion_colors.red }}
+                                  {%- elif repeat.item.entity is match "button." or repeat.item.entity is match "input_button." or repeat.item.entity is match "scene." -%} {{ nextion_colors.graylight }}
                                   {%- elif current_entity_state == 'on' or current_entity_state == 'open' -%} {{ repeat.item.button_icon_color }}
-                                  {%- elif current_entity_state == 'off' or current_entity_state == 'closed' -%} {{ color_03 }}
+                                  {%- elif current_entity_state == 'off' or current_entity_state == 'closed' -%} {{ nextion_colors.graylight }}
                                   {%- elif repeat.item.entity is match "person." and current_entity_state == 'home' -%} {{ repeat.item.button_icon_color }}
-                                  {%- elif repeat.item.entity is match "person." and current_entity_state != 'home' -%} {{ color_03 }}
+                                  {%- elif repeat.item.entity is match "person." and current_entity_state != 'home' -%} {{ nextion_colors.graylight }}
                                   {%- elif repeat.item.entity is match "climate." and current_entity_state != 'off' -%} {{ repeat.item.button_icon_color }}
-                                  {%- elif repeat.item.entity is match "climate." and current_entity_state == 'off' -%} {{ color_03 }}
+                                  {%- elif repeat.item.entity is match "climate." and current_entity_state == 'off' -%} {{ nextion_colors.graylight }}
                                   {%- endif -%}
                                 # LABEL Font Color
                                 btn_txt_font: >-
-                                  {%- if current_entity_state == 'unknown' or current_entity_state == 'unavailable' -%} {{ color_01 }}
-                                  {%- elif repeat.item.entity is match "button." or repeat.item.entity is match "input_button." or repeat.item.entity is match "scene." -%} {{ color_01 }}
-                                  {%- elif current_entity_state == 'on' or current_entity_state == 'open' -%} {{ color_02 }}
-                                  {%- elif current_entity_state == 'off' or current_entity_state == 'closed' -%} {{ color_01 }}
-                                  {%- elif repeat.item.entity is match "person." and current_entity_state == 'home' -%} {{ color_02 }}
-                                  {%- elif repeat.item.entity is match "person." and current_entity_state != 'home' -%} {{ color_01 }}
-                                  {%- elif repeat.item.entity is match "climate." and current_entity_state != 'off' -%} {{ color_02 }}
-                                  {%- elif repeat.item.entity is match "climate." and current_entity_state == 'off' -%} {{ color_01 }}
+                                  {%- if current_entity_state == 'unknown' or current_entity_state == 'unavailable' -%} {{ nextion_colors.white }}
+                                  {%- elif repeat.item.entity is match "button." or repeat.item.entity is match "input_button." or repeat.item.entity is match "scene." -%} {{ nextion_colors.white }}
+                                  {%- elif current_entity_state == 'on' or current_entity_state == 'open' -%} {{ nextion_colors.graydark }}
+                                  {%- elif current_entity_state == 'off' or current_entity_state == 'closed' -%} {{ nextion_colors.white }}
+                                  {%- elif repeat.item.entity is match "person." and current_entity_state == 'home' -%} {{ nextion_colors.graydark }}
+                                  {%- elif repeat.item.entity is match "person." and current_entity_state != 'home' -%} {{ nextion_colors.white }}
+                                  {%- elif repeat.item.entity is match "climate." and current_entity_state != 'off' -%} {{ nextion_colors.graydark }}
+                                  {%- elif repeat.item.entity is match "climate." and current_entity_state == 'off' -%} {{ nextion_colors.white }}
                                   {%- endif -%}
                                 # BRIGHTNESS Font Color
-                                btn_bri_font: "{{ color_02 }}"
+                                btn_bri_font: "{{ nextion_colors.graydark }}"
                                 # ICON Value
                                 btn_icon: >-
                                   {%- if current_entity_state == 'unknown' or current_entity_state == 'unavailable' -%} {{ button_icon_unknown }}
@@ -5391,42 +5642,42 @@ action:
                         - entity: "{{ entity09 }}"
                           button_icon: "{{ entity09_icon }}"
                           button_label: "{{ entity09_name }}"
-                          button_icon_color: "{{ entity09_icon_color }}"
+                          button_icon_color: "{{ entity09_icon_color | int(65535) }}"
                           button: buttonpage02.button01
                         - entity: "{{ entity10 }}"
                           button_icon: "{{ entity10_icon }}"
                           button_label: "{{ entity10_name }}"
-                          button_icon_color: "{{ entity10_icon_color }}"
+                          button_icon_color: "{{ entity10_icon_color | int(65535) }}"
                           button: buttonpage02.button02
                         - entity: "{{ entity11 }}"
                           button_icon: "{{ entity11_icon }}"
                           button_label: "{{ entity11_name }}"
-                          button_icon_color: "{{ entity11_icon_color }}"
+                          button_icon_color: "{{ entity11_icon_color | int(65535) }}"
                           button: buttonpage02.button03
                         - entity: "{{ entity12 }}"
                           button_icon: "{{ entity12_icon }}"
                           button_label: "{{ entity12_name }}"
-                          button_icon_color: "{{ entity12_icon_color }}"
+                          button_icon_color: "{{ entity12_icon_color | int(65535) }}"
                           button: buttonpage02.button04
                         - entity: "{{ entity13 }}"
                           button_icon: "{{ entity13_icon }}"
                           button_label: "{{ entity13_name }}"
-                          button_icon_color: "{{ entity13_icon_color }}"
+                          button_icon_color: "{{ entity13_icon_color | int(65535) }}"
                           button: buttonpage02.button05
                         - entity: "{{ entity14 }}"
                           button_icon: "{{ entity14_icon }}"
                           button_label: "{{ entity14_name }}"
-                          button_icon_color: "{{ entity14_icon_color }}"
+                          button_icon_color: "{{ entity14_icon_color | int(65535) }}"
                           button: buttonpage02.button06
                         - entity: "{{ entity15 }}"
                           button_icon: "{{ entity15_icon }}"
                           button_label: "{{ entity15_name }}"
-                          button_icon_color: "{{ entity15_icon_color }}"
+                          button_icon_color: "{{ entity15_icon_color | int(65535) }}"
                           button: buttonpage02.button07
                         - entity: "{{ entity16 }}"
                           button_icon: "{{ entity16_icon }}"
                           button_label: "{{ entity16_name }}"
-                          button_icon_color: "{{ entity16_icon_color }}"
+                          button_icon_color: "{{ entity16_icon_color | int(65535) }}"
                           button: buttonpage02.button08
                       sequence:
                         - if:
@@ -5465,39 +5716,39 @@ action:
                                   {%- endif -%}
                                 # TEXT, BRIGHTNESS and ICON Background
                                 btn_bg: >-
-                                  {%- if current_entity_state == 'unknown' or current_entity_state == 'unavailable' -%} {{ color_02 }}
-                                  {%- elif repeat.item.entity is match "button." or repeat.item.entity is match "input_button." or repeat.item.entity is match "scene." -%} {{ color_02 }}
-                                  {%- elif current_entity_state == 'on' or current_entity_state == 'open' -%} {{ color_01 }}
-                                  {%- elif current_entity_state == 'off' or current_entity_state == 'closed' -%} {{ color_02 }}
-                                  {%- elif repeat.item.entity is match "person." and current_entity_state == 'home' -%} {{ color_01 }}
-                                  {%- elif repeat.item.entity is match "person." and current_entity_state != 'home' -%} {{ color_02 }}
-                                  {%- elif repeat.item.entity is match "climate." and current_entity_state != 'off' -%} {{ color_01 }}
-                                  {%- elif repeat.item.entity is match "climate." and current_entity_state == 'off' -%} {{ color_02 }}
+                                  {%- if current_entity_state == 'unknown' or current_entity_state == 'unavailable' -%} {{ nextion_colors.graydark }}
+                                  {%- elif repeat.item.entity is match "button." or repeat.item.entity is match "input_button." or repeat.item.entity is match "scene." -%} {{ nextion_colors.graydark }}
+                                  {%- elif current_entity_state == 'on' or current_entity_state == 'open' -%} {{ nextion_colors.white }}
+                                  {%- elif current_entity_state == 'off' or current_entity_state == 'closed' -%} {{ nextion_colors.graydark }}
+                                  {%- elif repeat.item.entity is match "person." and current_entity_state == 'home' -%} {{ nextion_colors.white }}
+                                  {%- elif repeat.item.entity is match "person." and current_entity_state != 'home' -%} {{ nextion_colors.graydark }}
+                                  {%- elif repeat.item.entity is match "climate." and current_entity_state != 'off' -%} {{ nextion_colors.white }}
+                                  {%- elif repeat.item.entity is match "climate." and current_entity_state == 'off' -%} {{ nextion_colors.graydark }}
                                   {%- endif -%}
                                 # ICON Font Color
                                 btn_icon_font: >-
-                                  {%- if current_entity_state == 'unknown' or current_entity_state == 'unavailable' -%} {{ color_05 }}
-                                  {%- elif repeat.item.entity is match "button." or repeat.item.entity is match "input_button." or repeat.item.entity is match "scene." -%} {{ color_03 }}
+                                  {%- if current_entity_state == 'unknown' or current_entity_state == 'unavailable' -%} {{ nextion_colors.red }}
+                                  {%- elif repeat.item.entity is match "button." or repeat.item.entity is match "input_button." or repeat.item.entity is match "scene." -%} {{ nextion_colors.graylight }}
                                   {%- elif current_entity_state == 'on' or current_entity_state == 'open' -%} {{ repeat.item.button_icon_color }}
-                                  {%- elif current_entity_state == 'off' or current_entity_state == 'closed' -%} {{ color_03 }}
+                                  {%- elif current_entity_state == 'off' or current_entity_state == 'closed' -%} {{ nextion_colors.graylight }}
                                   {%- elif repeat.item.entity is match "person." and current_entity_state == 'home' -%} {{ repeat.item.button_icon_color }}
-                                  {%- elif repeat.item.entity is match "person." and current_entity_state != 'home' -%} {{ color_03 }}
+                                  {%- elif repeat.item.entity is match "person." and current_entity_state != 'home' -%} {{ nextion_colors.graylight }}
                                   {%- elif repeat.item.entity is match "climate." and current_entity_state != 'off' -%} {{ repeat.item.button_icon_color }}
-                                  {%- elif repeat.item.entity is match "climate." and current_entity_state == 'off' -%} {{ color_03 }}
+                                  {%- elif repeat.item.entity is match "climate." and current_entity_state == 'off' -%} {{ nextion_colors.graylight }}
                                   {%- endif -%}
                                 # LABEL Font Color
                                 btn_txt_font: >-
-                                  {%- if current_entity_state == 'unknown' or current_entity_state == 'unavailable' -%} {{ color_01 }}
-                                  {%- elif repeat.item.entity is match "button." or repeat.item.entity is match "input_button." or repeat.item.entity is match "scene." -%} {{ color_01 }}
-                                  {%- elif current_entity_state == 'on' or current_entity_state == 'open' -%} {{ color_02 }}
-                                  {%- elif current_entity_state == 'off' or current_entity_state == 'closed' -%} {{ color_01 }}
-                                  {%- elif repeat.item.entity is match "person." and current_entity_state == 'home' -%} {{ color_02 }}
-                                  {%- elif repeat.item.entity is match "person." and current_entity_state != 'home' -%} {{ color_01 }}
-                                  {%- elif repeat.item.entity is match "climate." and current_entity_state != 'off' -%} {{ color_02 }}
-                                  {%- elif repeat.item.entity is match "climate." and current_entity_state == 'off' -%} {{ color_01 }}
+                                  {%- if current_entity_state == 'unknown' or current_entity_state == 'unavailable' -%} {{ nextion_colors.white }}
+                                  {%- elif repeat.item.entity is match "button." or repeat.item.entity is match "input_button." or repeat.item.entity is match "scene." -%} {{ nextion_colors.white }}
+                                  {%- elif current_entity_state == 'on' or current_entity_state == 'open' -%} {{ nextion_colors.graydark }}
+                                  {%- elif current_entity_state == 'off' or current_entity_state == 'closed' -%} {{ nextion_colors.white }}
+                                  {%- elif repeat.item.entity is match "person." and current_entity_state == 'home' -%} {{ nextion_colors.graydark }}
+                                  {%- elif repeat.item.entity is match "person." and current_entity_state != 'home' -%} {{ nextion_colors.white }}
+                                  {%- elif repeat.item.entity is match "climate." and current_entity_state != 'off' -%} {{ nextion_colors.graydark }}
+                                  {%- elif repeat.item.entity is match "climate." and current_entity_state == 'off' -%} {{ nextion_colors.white }}
                                   {%- endif -%}
                                 # BRIGHTNESS Font Color
-                                btn_bri_font: "{{ color_02 }}"
+                                btn_bri_font: "{{ nextion_colors.graydark }}"
                                 # ICON Value
                                 btn_icon: >-
                                   {%- if current_entity_state == 'unknown' or current_entity_state == 'unavailable' -%} {{ button_icon_unknown }}
@@ -5642,42 +5893,42 @@ action:
                         - entity: "{{ entity17 }}"
                           button_icon: "{{ entity17_icon }}"
                           button_label: "{{ entity17_name }}"
-                          button_icon_color: "{{ entity17_icon_color }}"
+                          button_icon_color: "{{ entity17_icon_color | int(65535) }}"
                           button: buttonpage03.button01
                         - entity: "{{ entity18 }}"
                           button_icon: "{{ entity18_icon }}"
                           button_label: "{{ entity18_name }}"
-                          button_icon_color: "{{ entity18_icon_color }}"
+                          button_icon_color: "{{ entity18_icon_color | int(65535) }}"
                           button: buttonpage03.button02
                         - entity: "{{ entity19 }}"
                           button_icon: "{{ entity19_icon }}"
                           button_label: "{{ entity19_name }}"
-                          button_icon_color: "{{ entity19_icon_color }}"
+                          button_icon_color: "{{ entity19_icon_color | int(65535) }}"
                           button: buttonpage03.button03
                         - entity: "{{ entity20 }}"
                           button_icon: "{{ entity20_icon }}"
                           button_label: "{{ entity20_name }}"
-                          button_icon_color: "{{ entity20_icon_color }}"
+                          button_icon_color: "{{ entity20_icon_color | int(65535) }}"
                           button: buttonpage03.button04
                         - entity: "{{ entity21 }}"
                           button_icon: "{{ entity21_icon }}"
                           button_label: "{{ entity21_name }}"
-                          button_icon_color: "{{ entity21_icon_color }}"
+                          button_icon_color: "{{ entity21_icon_color | int(65535) }}"
                           button: buttonpage03.button05
                         - entity: "{{ entity22 }}"
                           button_icon: "{{ entity22_icon }}"
                           button_label: "{{ entity22_name }}"
-                          button_icon_color: "{{ entity22_icon_color }}"
+                          button_icon_color: "{{ entity22_icon_color | int(65535) }}"
                           button: buttonpage03.button06
                         - entity: "{{ entity23 }}"
                           button_icon: "{{ entity23_icon }}"
                           button_label: "{{ entity23_name }}"
-                          button_icon_color: "{{ entity23_icon_color }}"
+                          button_icon_color: "{{ entity23_icon_color | int(65535) }}"
                           button: buttonpage03.button07
                         - entity: "{{ entity24 }}"
                           button_icon: "{{ entity24_icon }}"
                           button_label: "{{ entity24_name }}"
-                          button_icon_color: "{{ entity24_icon_color }}"
+                          button_icon_color: "{{ entity24_icon_color | int(65535) }}"
                           button: buttonpage03.button08
                       sequence:
                         - if:
@@ -5716,39 +5967,39 @@ action:
                                   {%- endif -%}
                                 # TEXT, BRIGHTNESS and ICON Background
                                 btn_bg: >-
-                                  {%- if current_entity_state == 'unknown' or current_entity_state == 'unavailable' -%} {{ color_02 }}
-                                  {%- elif repeat.item.entity is match "button." or repeat.item.entity is match "input_button." or repeat.item.entity is match "scene." -%} {{ color_02 }}
-                                  {%- elif current_entity_state == 'on' or current_entity_state == 'open' -%} {{ color_01 }}
-                                  {%- elif current_entity_state == 'off' or current_entity_state == 'closed' -%} {{ color_02 }}
-                                  {%- elif repeat.item.entity is match "person." and current_entity_state == 'home' -%} {{ color_01 }}
-                                  {%- elif repeat.item.entity is match "person." and current_entity_state != 'home' -%} {{ color_02 }}
-                                  {%- elif repeat.item.entity is match "climate." and current_entity_state != 'off' -%} {{ color_01 }}
-                                  {%- elif repeat.item.entity is match "climate." and current_entity_state == 'off' -%} {{ color_02 }}
+                                  {%- if current_entity_state == 'unknown' or current_entity_state == 'unavailable' -%} {{ nextion_colors.graydark }}
+                                  {%- elif repeat.item.entity is match "button." or repeat.item.entity is match "input_button." or repeat.item.entity is match "scene." -%} {{ nextion_colors.graydark }}
+                                  {%- elif current_entity_state == 'on' or current_entity_state == 'open' -%} {{ nextion_colors.white }}
+                                  {%- elif current_entity_state == 'off' or current_entity_state == 'closed' -%} {{ nextion_colors.graydark }}
+                                  {%- elif repeat.item.entity is match "person." and current_entity_state == 'home' -%} {{ nextion_colors.white }}
+                                  {%- elif repeat.item.entity is match "person." and current_entity_state != 'home' -%} {{ nextion_colors.graydark }}
+                                  {%- elif repeat.item.entity is match "climate." and current_entity_state != 'off' -%} {{ nextion_colors.white }}
+                                  {%- elif repeat.item.entity is match "climate." and current_entity_state == 'off' -%} {{ nextion_colors.graydark }}
                                   {%- endif -%}
                                 # ICON Font Color
                                 btn_icon_font: >-
-                                  {%- if current_entity_state == 'unknown' or current_entity_state == 'unavailable' -%} {{ color_05 }}
-                                  {%- elif repeat.item.entity is match "button." or repeat.item.entity is match "input_button." or repeat.item.entity is match "scene." -%} {{ color_03 }}
+                                  {%- if current_entity_state == 'unknown' or current_entity_state == 'unavailable' -%} {{ nextion_colors.red }}
+                                  {%- elif repeat.item.entity is match "button." or repeat.item.entity is match "input_button." or repeat.item.entity is match "scene." -%} {{ nextion_colors.graylight }}
                                   {%- elif current_entity_state == 'on' or current_entity_state == 'open' -%} {{ repeat.item.button_icon_color }}
-                                  {%- elif current_entity_state == 'off' or current_entity_state == 'closed' -%} {{ color_03 }}
+                                  {%- elif current_entity_state == 'off' or current_entity_state == 'closed' -%} {{ nextion_colors.graylight }}
                                   {%- elif repeat.item.entity is match "person." and current_entity_state == 'home' -%} {{ repeat.item.button_icon_color }}
-                                  {%- elif repeat.item.entity is match "person." and current_entity_state != 'home' -%} {{ color_03 }}
+                                  {%- elif repeat.item.entity is match "person." and current_entity_state != 'home' -%} {{ nextion_colors.graylight }}
                                   {%- elif repeat.item.entity is match "climate." and current_entity_state != 'off' -%} {{ repeat.item.button_icon_color }}
-                                  {%- elif repeat.item.entity is match "climate." and current_entity_state == 'off' -%} {{ color_03 }}
+                                  {%- elif repeat.item.entity is match "climate." and current_entity_state == 'off' -%} {{ nextion_colors.graylight }}
                                   {%- endif -%}
                                 # LABEL Font Color
                                 btn_txt_font: >-
-                                  {%- if current_entity_state == 'unknown' or current_entity_state == 'unavailable' -%} {{ color_01 }}
-                                  {%- elif repeat.item.entity is match "button." or repeat.item.entity is match "input_button." or repeat.item.entity is match "scene." -%} {{ color_01 }}
-                                  {%- elif current_entity_state == 'on' or current_entity_state == 'open' -%} {{ color_02 }}
-                                  {%- elif current_entity_state == 'off' or current_entity_state == 'closed' -%} {{ color_01 }}
-                                  {%- elif repeat.item.entity is match "person." and current_entity_state == 'home' -%} {{ color_02 }}
-                                  {%- elif repeat.item.entity is match "person." and current_entity_state != 'home' -%} {{ color_01 }}
-                                  {%- elif repeat.item.entity is match "climate." and current_entity_state != 'off' -%} {{ color_02 }}
-                                  {%- elif repeat.item.entity is match "climate." and current_entity_state == 'off' -%} {{ color_01 }}
+                                  {%- if current_entity_state == 'unknown' or current_entity_state == 'unavailable' -%} {{ nextion_colors.white }}
+                                  {%- elif repeat.item.entity is match "button." or repeat.item.entity is match "input_button." or repeat.item.entity is match "scene." -%} {{ nextion_colors.white }}
+                                  {%- elif current_entity_state == 'on' or current_entity_state == 'open' -%} {{ nextion_colors.graydark }}
+                                  {%- elif current_entity_state == 'off' or current_entity_state == 'closed' -%} {{ nextion_colors.white }}
+                                  {%- elif repeat.item.entity is match "person." and current_entity_state == 'home' -%} {{ nextion_colors.graydark }}
+                                  {%- elif repeat.item.entity is match "person." and current_entity_state != 'home' -%} {{ nextion_colors.white }}
+                                  {%- elif repeat.item.entity is match "climate." and current_entity_state != 'off' -%} {{ nextion_colors.graydark }}
+                                  {%- elif repeat.item.entity is match "climate." and current_entity_state == 'off' -%} {{ nextion_colors.white }}
                                   {%- endif -%}
                                 # BRIGHTNESS Font Color
-                                btn_bri_font: "{{ color_02 }}"
+                                btn_bri_font: "{{ nextion_colors.graydark }}"
                                 # ICON Value
                                 btn_icon: >-
                                   {%- if current_entity_state == 'unknown' or current_entity_state == 'unavailable' -%} {{ button_icon_unknown }}
@@ -5893,42 +6144,42 @@ action:
                         - entity: "{{ entity25 }}"
                           button_icon: "{{ entity25_icon }}"
                           button_label: "{{ entity25_name }}"
-                          button_icon_color: "{{ entity25_icon_color }}"
+                          button_icon_color: "{{ entity25_icon_color | int(65535) }}"
                           button: buttonpage04.button01
                         - entity: "{{ entity26 }}"
                           button_icon: "{{ entity26_icon }}"
                           button_label: "{{ entity26_name }}"
-                          button_icon_color: "{{ entity26_icon_color }}"
+                          button_icon_color: "{{ entity26_icon_color | int(65535) }}"
                           button: buttonpage04.button02
                         - entity: "{{ entity27 }}"
                           button_icon: "{{ entity27_icon }}"
                           button_label: "{{ entity27_name }}"
-                          button_icon_color: "{{ entity27_icon_color }}"
+                          button_icon_color: "{{ entity27_icon_color | int(65535) }}"
                           button: buttonpage04.button03
                         - entity: "{{ entity28 }}"
                           button_icon: "{{ entity28_icon }}"
                           button_label: "{{ entity28_name }}"
-                          button_icon_color: "{{ entity28_icon_color }}"
+                          button_icon_color: "{{ entity28_icon_color | int(65535) }}"
                           button: buttonpage04.button04
                         - entity: "{{ entity29 }}"
                           button_icon: "{{ entity29_icon }}"
                           button_label: "{{ entity29_name }}"
-                          button_icon_color: "{{ entity29_icon_color }}"
+                          button_icon_color: "{{ entity29_icon_color | int(65535) }}"
                           button: buttonpage04.button05
                         - entity: "{{ entity30 }}"
                           button_icon: "{{ entity30_icon }}"
                           button_label: "{{ entity30_name }}"
-                          button_icon_color: "{{ entity30_icon_color }}"
+                          button_icon_color: "{{ entity30_icon_color | int(65535) }}"
                           button: buttonpage04.button06
                         - entity: "{{ entity31 }}"
                           button_icon: "{{ entity31_icon }}"
                           button_label: "{{ entity31_name }}"
-                          button_icon_color: "{{ entity31_icon_color }}"
+                          button_icon_color: "{{ entity31_icon_color | int(65535) }}"
                           button: buttonpage04.button07
                         - entity: "{{ entity32 }}"
                           button_icon: "{{ entity32_icon }}"
                           button_label: "{{ entity32_name }}"
-                          button_icon_color: "{{ entity32_icon_color }}"
+                          button_icon_color: "{{ entity32_icon_color | int(65535) }}"
                           button: buttonpage04.button08
                       sequence:
                         - if:
@@ -5967,39 +6218,39 @@ action:
                                   {%- endif -%}
                                 # TEXT, BRIGHTNESS and ICON Background
                                 btn_bg: >-
-                                  {%- if current_entity_state == 'unknown' or current_entity_state == 'unavailable' -%} {{ color_02 }}
-                                  {%- elif repeat.item.entity is match "button." or repeat.item.entity is match "input_button." or repeat.item.entity is match "scene." -%} {{ color_02 }}
-                                  {%- elif current_entity_state == 'on' or current_entity_state == 'open' -%} {{ color_01 }}
-                                  {%- elif current_entity_state == 'off' or current_entity_state == 'closed' -%} {{ color_02 }}
-                                  {%- elif repeat.item.entity is match "person." and current_entity_state == 'home' -%} {{ color_01 }}
-                                  {%- elif repeat.item.entity is match "person." and current_entity_state != 'home' -%} {{ color_02 }}
-                                  {%- elif repeat.item.entity is match "climate." and current_entity_state != 'off' -%} {{ color_01 }}
-                                  {%- elif repeat.item.entity is match "climate." and current_entity_state == 'off' -%} {{ color_02 }}
+                                  {%- if current_entity_state == 'unknown' or current_entity_state == 'unavailable' -%} {{ nextion_colors.graydark }}
+                                  {%- elif repeat.item.entity is match "button." or repeat.item.entity is match "input_button." or repeat.item.entity is match "scene." -%} {{ nextion_colors.graydark }}
+                                  {%- elif current_entity_state == 'on' or current_entity_state == 'open' -%} {{ nextion_colors.white }}
+                                  {%- elif current_entity_state == 'off' or current_entity_state == 'closed' -%} {{ nextion_colors.graydark }}
+                                  {%- elif repeat.item.entity is match "person." and current_entity_state == 'home' -%} {{ nextion_colors.white }}
+                                  {%- elif repeat.item.entity is match "person." and current_entity_state != 'home' -%} {{ nextion_colors.graydark }}
+                                  {%- elif repeat.item.entity is match "climate." and current_entity_state != 'off' -%} {{ nextion_colors.white }}
+                                  {%- elif repeat.item.entity is match "climate." and current_entity_state == 'off' -%} {{ nextion_colors.graydark }}
                                   {%- endif -%}
                                 # ICON Font Color
                                 btn_icon_font: >-
-                                  {%- if current_entity_state == 'unknown' or current_entity_state == 'unavailable' -%} {{ color_05 }}
-                                  {%- elif repeat.item.entity is match "button." or repeat.item.entity is match "input_button." or repeat.item.entity is match "scene." -%} {{ color_03 }}
+                                  {%- if current_entity_state == 'unknown' or current_entity_state == 'unavailable' -%} {{ nextion_colors.red }}
+                                  {%- elif repeat.item.entity is match "button." or repeat.item.entity is match "input_button." or repeat.item.entity is match "scene." -%} {{ nextion_colors.graylight }}
                                   {%- elif current_entity_state == 'on' or current_entity_state == 'open' -%} {{ repeat.item.button_icon_color }}
-                                  {%- elif current_entity_state == 'off' or current_entity_state == 'closed' -%} {{ color_03 }}
+                                  {%- elif current_entity_state == 'off' or current_entity_state == 'closed' -%} {{ nextion_colors.graylight }}
                                   {%- elif repeat.item.entity is match "person." and current_entity_state == 'home' -%} {{ repeat.item.button_icon_color }}
-                                  {%- elif repeat.item.entity is match "person." and current_entity_state != 'home' -%} {{ color_03 }}
+                                  {%- elif repeat.item.entity is match "person." and current_entity_state != 'home' -%} {{ nextion_colors.graylight }}
                                   {%- elif repeat.item.entity is match "climate." and current_entity_state != 'off' -%} {{ repeat.item.button_icon_color }}
-                                  {%- elif repeat.item.entity is match "climate." and current_entity_state == 'off' -%} {{ color_03 }}
+                                  {%- elif repeat.item.entity is match "climate." and current_entity_state == 'off' -%} {{ nextion_colors.graylight }}
                                   {%- endif -%}
                                 # LABEL Font Color
                                 btn_txt_font: >-
-                                  {%- if current_entity_state == 'unknown' or current_entity_state == 'unavailable' -%} {{ color_01 }}
-                                  {%- elif repeat.item.entity is match "button." or repeat.item.entity is match "input_button." or repeat.item.entity is match "scene." -%} {{ color_01 }}
-                                  {%- elif current_entity_state == 'on' or current_entity_state == 'open' -%} {{ color_02 }}
-                                  {%- elif current_entity_state == 'off' or current_entity_state == 'closed' -%} {{ color_01 }}
-                                  {%- elif repeat.item.entity is match "person." and current_entity_state == 'home' -%} {{ color_02 }}
-                                  {%- elif repeat.item.entity is match "person." and current_entity_state != 'home' -%} {{ color_01 }}
-                                  {%- elif repeat.item.entity is match "climate." and current_entity_state != 'off' -%} {{ color_02 }}
-                                  {%- elif repeat.item.entity is match "climate." and current_entity_state == 'off' -%} {{ color_01 }}
+                                  {%- if current_entity_state == 'unknown' or current_entity_state == 'unavailable' -%} {{ nextion_colors.white }}
+                                  {%- elif repeat.item.entity is match "button." or repeat.item.entity is match "input_button." or repeat.item.entity is match "scene." -%} {{ nextion_colors.white }}
+                                  {%- elif current_entity_state == 'on' or current_entity_state == 'open' -%} {{ nextion_colors.graydark }}
+                                  {%- elif current_entity_state == 'off' or current_entity_state == 'closed' -%} {{ nextion_colors.white }}
+                                  {%- elif repeat.item.entity is match "person." and current_entity_state == 'home' -%} {{ nextion_colors.graydark }}
+                                  {%- elif repeat.item.entity is match "person." and current_entity_state != 'home' -%} {{ nextion_colors.white }}
+                                  {%- elif repeat.item.entity is match "climate." and current_entity_state != 'off' -%} {{ nextion_colors.graydark }}
+                                  {%- elif repeat.item.entity is match "climate." and current_entity_state == 'off' -%} {{ nextion_colors.white }}
                                   {%- endif -%}
                                 # BRIGHTNESS Font Color
-                                btn_bri_font: "{{ color_02 }}"
+                                btn_bri_font: "{{ nextion_colors.graydark }}"
                                 # ICON Value
                                 btn_icon: >-
                                   {%- if current_entity_state == 'unknown' or current_entity_state == 'unavailable' -%} {{ button_icon_unknown }}
@@ -6135,7 +6386,7 @@ action:
                         {%- endif -%}
                       lightsettings_icon_font_color: >-
                         {%- if states(entity_long) == 'on' -%} {{ entity_long_icon_color }}
-                        {%- else -%} {{ color_03 }}
+                        {%- else -%} {{ nextion_colors.graylight }}
                         {%- endif -%}
                   - delay:
                       milliseconds: "{{ delay_value }}"
@@ -6227,7 +6478,7 @@ action:
                         {%- endif -%}
                       coversettings_icon_font_color: >-
                         {%- if states(entity_long) == 'open' -%} {{ entity_long_icon_color }}
-                        {%- else -%} {{ color_03 }}
+                        {%- else -%} {{ nextion_colors.graylight }}
                         {%- endif -%}
                   - delay:
                       milliseconds: "{{ delay_value }}"
@@ -8107,65 +8358,65 @@ action:
                 {%- endif -%}
               # TEXT and BRIGHTNESS and ICON Background
               btn_bg: >-
-                {%- if trigger.to_state.entity_id is match "button." or trigger.to_state.entity_id is match "input_button." or trigger.to_state.entity_id is match "scene." -%} {{ color_01 }}
-                {%- elif trigger.to_state.state == 'on' or trigger.to_state.state == 'open' -%} {{ color_01 }}
-                {%- elif trigger.to_state.state == 'off' or trigger.to_state.state == 'closed' -%} {{ color_02 }}
-                {%- elif trigger.to_state.entity_id is match "person." and trigger.to_state.state == 'home' -%} {{ color_01 }}
-                {%- elif trigger.to_state.entity_id is match "person." and trigger.to_state.state != 'home' -%} {{ color_02 }}
-                {%- elif trigger.to_state.entity_id is match "climate." and trigger.to_state.state != 'off' -%} {{ color_01 }}
-                {%- elif trigger.to_state.entity_id is match "climate." and trigger.to_state.state == 'off' -%} {{ color_02 }}
+                {%- if trigger.to_state.entity_id is match "button." or trigger.to_state.entity_id is match "input_button." or trigger.to_state.entity_id is match "scene." -%} {{ nextion_colors.white }}
+                {%- elif trigger.to_state.state == 'on' or trigger.to_state.state == 'open' -%} {{ nextion_colors.white }}
+                {%- elif trigger.to_state.state == 'off' or trigger.to_state.state == 'closed' -%} {{ nextion_colors.graydark }}
+                {%- elif trigger.to_state.entity_id is match "person." and trigger.to_state.state == 'home' -%} {{ nextion_colors.white }}
+                {%- elif trigger.to_state.entity_id is match "person." and trigger.to_state.state != 'home' -%} {{ nextion_colors.graydark }}
+                {%- elif trigger.to_state.entity_id is match "climate." and trigger.to_state.state != 'off' -%} {{ nextion_colors.white }}
+                {%- elif trigger.to_state.entity_id is match "climate." and trigger.to_state.state == 'off' -%} {{ nextion_colors.graydark }}
                 {%- endif -%}
               # ICON Font Color
               btn_icon_font: >-
-                {%- if trigger.entity_id == entity01 and ((trigger.to_state.state == 'on' or trigger.to_state.state == 'open') or (trigger.to_state.entity_id is match "button.") or (trigger.to_state.entity_id is match "input_button.") or (trigger.to_state.entity_id is match "scene.") or (trigger.to_state.entity_id is match "person." and trigger.to_state.state == 'home') or (trigger.to_state.entity_id is match "climate." and trigger.to_state.state != 'off') ) -%} {{ entity01_icon_color }}
-                {%- elif trigger.entity_id == entity02 and ((trigger.to_state.state == 'on' or trigger.to_state.state == 'open') or (trigger.to_state.entity_id is match "button.") or (trigger.to_state.entity_id is match "input_button.") or (trigger.to_state.entity_id is match "scene.") or (trigger.to_state.entity_id is match "person." and trigger.to_state.state == 'home') or (trigger.to_state.entity_id is match "climate." and trigger.to_state.state != 'off') ) -%} {{ entity02_icon_color }}
-                {%- elif trigger.entity_id == entity03 and ((trigger.to_state.state == 'on' or trigger.to_state.state == 'open') or (trigger.to_state.entity_id is match "button.") or (trigger.to_state.entity_id is match "input_button.") or (trigger.to_state.entity_id is match "scene.") or (trigger.to_state.entity_id is match "person." and trigger.to_state.state == 'home') or (trigger.to_state.entity_id is match "climate." and trigger.to_state.state != 'off') ) -%} {{ entity03_icon_color }}
-                {%- elif trigger.entity_id == entity04 and ((trigger.to_state.state == 'on' or trigger.to_state.state == 'open') or (trigger.to_state.entity_id is match "button.") or (trigger.to_state.entity_id is match "input_button.") or (trigger.to_state.entity_id is match "scene.") or (trigger.to_state.entity_id is match "person." and trigger.to_state.state == 'home') or (trigger.to_state.entity_id is match "climate." and trigger.to_state.state != 'off') ) -%} {{ entity04_icon_color }}
-                {%- elif trigger.entity_id == entity05 and ((trigger.to_state.state == 'on' or trigger.to_state.state == 'open') or (trigger.to_state.entity_id is match "button.") or (trigger.to_state.entity_id is match "input_button.") or (trigger.to_state.entity_id is match "scene.") or (trigger.to_state.entity_id is match "person." and trigger.to_state.state == 'home') or (trigger.to_state.entity_id is match "climate." and trigger.to_state.state != 'off') ) -%} {{ entity05_icon_color }}
-                {%- elif trigger.entity_id == entity06 and ((trigger.to_state.state == 'on' or trigger.to_state.state == 'open') or (trigger.to_state.entity_id is match "button.") or (trigger.to_state.entity_id is match "input_button.") or (trigger.to_state.entity_id is match "scene.") or (trigger.to_state.entity_id is match "person." and trigger.to_state.state == 'home') or (trigger.to_state.entity_id is match "climate." and trigger.to_state.state != 'off') ) -%} {{ entity06_icon_color }}
-                {%- elif trigger.entity_id == entity07 and ((trigger.to_state.state == 'on' or trigger.to_state.state == 'open') or (trigger.to_state.entity_id is match "button.") or (trigger.to_state.entity_id is match "input_button.") or (trigger.to_state.entity_id is match "scene.") or (trigger.to_state.entity_id is match "person." and trigger.to_state.state == 'home') or (trigger.to_state.entity_id is match "climate." and trigger.to_state.state != 'off') ) -%} {{ entity07_icon_color }}
-                {%- elif trigger.entity_id == entity08 and ((trigger.to_state.state == 'on' or trigger.to_state.state == 'open') or (trigger.to_state.entity_id is match "button.") or (trigger.to_state.entity_id is match "input_button.") or (trigger.to_state.entity_id is match "scene.") or (trigger.to_state.entity_id is match "person." and trigger.to_state.state == 'home') or (trigger.to_state.entity_id is match "climate." and trigger.to_state.state != 'off') ) -%} {{ entity08_icon_color }}
-                {%- elif trigger.entity_id == entity09 and ((trigger.to_state.state == 'on' or trigger.to_state.state == 'open') or (trigger.to_state.entity_id is match "button.") or (trigger.to_state.entity_id is match "input_button.") or (trigger.to_state.entity_id is match "scene.") or (trigger.to_state.entity_id is match "person." and trigger.to_state.state == 'home') or (trigger.to_state.entity_id is match "climate." and trigger.to_state.state != 'off') ) -%} {{ entity09_icon_color }}
-                {%- elif trigger.entity_id == entity10 and ((trigger.to_state.state == 'on' or trigger.to_state.state == 'open') or (trigger.to_state.entity_id is match "button.") or (trigger.to_state.entity_id is match "input_button.") or (trigger.to_state.entity_id is match "scene.") or (trigger.to_state.entity_id is match "person." and trigger.to_state.state == 'home') or (trigger.to_state.entity_id is match "climate." and trigger.to_state.state != 'off') ) -%} {{ entity10_icon_color }}
-                {%- elif trigger.entity_id == entity11 and ((trigger.to_state.state == 'on' or trigger.to_state.state == 'open') or (trigger.to_state.entity_id is match "button.") or (trigger.to_state.entity_id is match "input_button.") or (trigger.to_state.entity_id is match "scene.") or (trigger.to_state.entity_id is match "person." and trigger.to_state.state == 'home') or (trigger.to_state.entity_id is match "climate." and trigger.to_state.state != 'off') ) -%} {{ entity11_icon_color }}
-                {%- elif trigger.entity_id == entity12 and ((trigger.to_state.state == 'on' or trigger.to_state.state == 'open') or (trigger.to_state.entity_id is match "button.") or (trigger.to_state.entity_id is match "input_button.") or (trigger.to_state.entity_id is match "scene.") or (trigger.to_state.entity_id is match "person." and trigger.to_state.state == 'home') or (trigger.to_state.entity_id is match "climate." and trigger.to_state.state != 'off') ) -%} {{ entity12_icon_color }}
-                {%- elif trigger.entity_id == entity13 and ((trigger.to_state.state == 'on' or trigger.to_state.state == 'open') or (trigger.to_state.entity_id is match "button.") or (trigger.to_state.entity_id is match "input_button.") or (trigger.to_state.entity_id is match "scene.") or (trigger.to_state.entity_id is match "person." and trigger.to_state.state == 'home') or (trigger.to_state.entity_id is match "climate." and trigger.to_state.state != 'off') ) -%} {{ entity13_icon_color }}
-                {%- elif trigger.entity_id == entity14 and ((trigger.to_state.state == 'on' or trigger.to_state.state == 'open') or (trigger.to_state.entity_id is match "button.") or (trigger.to_state.entity_id is match "input_button.") or (trigger.to_state.entity_id is match "scene.") or (trigger.to_state.entity_id is match "person." and trigger.to_state.state == 'home') or (trigger.to_state.entity_id is match "climate." and trigger.to_state.state != 'off') ) -%} {{ entity14_icon_color }}
-                {%- elif trigger.entity_id == entity15 and ((trigger.to_state.state == 'on' or trigger.to_state.state == 'open') or (trigger.to_state.entity_id is match "button.") or (trigger.to_state.entity_id is match "input_button.") or (trigger.to_state.entity_id is match "scene.") or (trigger.to_state.entity_id is match "person." and trigger.to_state.state == 'home') or (trigger.to_state.entity_id is match "climate." and trigger.to_state.state != 'off') ) -%} {{ entity15_icon_color }}
-                {%- elif trigger.entity_id == entity16 and ((trigger.to_state.state == 'on' or trigger.to_state.state == 'open') or (trigger.to_state.entity_id is match "button.") or (trigger.to_state.entity_id is match "input_button.") or (trigger.to_state.entity_id is match "scene.") or (trigger.to_state.entity_id is match "person." and trigger.to_state.state == 'home') or (trigger.to_state.entity_id is match "climate." and trigger.to_state.state != 'off') ) -%} {{ entity16_icon_color }}
-                {%- elif trigger.entity_id == entity17 and ((trigger.to_state.state == 'on' or trigger.to_state.state == 'open') or (trigger.to_state.entity_id is match "button.") or (trigger.to_state.entity_id is match "input_button.") or (trigger.to_state.entity_id is match "scene.") or (trigger.to_state.entity_id is match "person." and trigger.to_state.state == 'home') or (trigger.to_state.entity_id is match "climate." and trigger.to_state.state != 'off') ) -%} {{ entity17_icon_color }}
-                {%- elif trigger.entity_id == entity18 and ((trigger.to_state.state == 'on' or trigger.to_state.state == 'open') or (trigger.to_state.entity_id is match "button.") or (trigger.to_state.entity_id is match "input_button.") or (trigger.to_state.entity_id is match "scene.") or (trigger.to_state.entity_id is match "person." and trigger.to_state.state == 'home') or (trigger.to_state.entity_id is match "climate." and trigger.to_state.state != 'off') ) -%} {{ entity18_icon_color }}
-                {%- elif trigger.entity_id == entity19 and ((trigger.to_state.state == 'on' or trigger.to_state.state == 'open') or (trigger.to_state.entity_id is match "button.") or (trigger.to_state.entity_id is match "input_button.") or (trigger.to_state.entity_id is match "scene.") or (trigger.to_state.entity_id is match "person." and trigger.to_state.state == 'home') or (trigger.to_state.entity_id is match "climate." and trigger.to_state.state != 'off') ) -%} {{ entity19_icon_color }}
-                {%- elif trigger.entity_id == entity20 and ((trigger.to_state.state == 'on' or trigger.to_state.state == 'open') or (trigger.to_state.entity_id is match "button.") or (trigger.to_state.entity_id is match "input_button.") or (trigger.to_state.entity_id is match "scene.") or (trigger.to_state.entity_id is match "person." and trigger.to_state.state == 'home') or (trigger.to_state.entity_id is match "climate." and trigger.to_state.state != 'off') ) -%} {{ entity20_icon_color }}
-                {%- elif trigger.entity_id == entity21 and ((trigger.to_state.state == 'on' or trigger.to_state.state == 'open') or (trigger.to_state.entity_id is match "button.") or (trigger.to_state.entity_id is match "input_button.") or (trigger.to_state.entity_id is match "scene.") or (trigger.to_state.entity_id is match "person." and trigger.to_state.state == 'home') or (trigger.to_state.entity_id is match "climate." and trigger.to_state.state != 'off') ) -%} {{ entity21_icon_color }}
-                {%- elif trigger.entity_id == entity22 and ((trigger.to_state.state == 'on' or trigger.to_state.state == 'open') or (trigger.to_state.entity_id is match "button.") or (trigger.to_state.entity_id is match "input_button.") or (trigger.to_state.entity_id is match "scene.") or (trigger.to_state.entity_id is match "person." and trigger.to_state.state == 'home') or (trigger.to_state.entity_id is match "climate." and trigger.to_state.state != 'off') ) -%} {{ entity22_icon_color }}
-                {%- elif trigger.entity_id == entity23 and ((trigger.to_state.state == 'on' or trigger.to_state.state == 'open') or (trigger.to_state.entity_id is match "button.") or (trigger.to_state.entity_id is match "input_button.") or (trigger.to_state.entity_id is match "scene.") or (trigger.to_state.entity_id is match "person." and trigger.to_state.state == 'home') or (trigger.to_state.entity_id is match "climate." and trigger.to_state.state != 'off') ) -%} {{ entity23_icon_color }}
-                {%- elif trigger.entity_id == entity24 and ((trigger.to_state.state == 'on' or trigger.to_state.state == 'open') or (trigger.to_state.entity_id is match "button.") or (trigger.to_state.entity_id is match "input_button.") or (trigger.to_state.entity_id is match "scene.") or (trigger.to_state.entity_id is match "person." and trigger.to_state.state == 'home') or (trigger.to_state.entity_id is match "climate." and trigger.to_state.state != 'off') ) -%} {{ entity24_icon_color }}
-                {%- elif trigger.entity_id == entity25 and ((trigger.to_state.state == 'on' or trigger.to_state.state == 'open') or (trigger.to_state.entity_id is match "button.") or (trigger.to_state.entity_id is match "input_button.") or (trigger.to_state.entity_id is match "scene.") or (trigger.to_state.entity_id is match "person." and trigger.to_state.state == 'home') or (trigger.to_state.entity_id is match "climate." and trigger.to_state.state != 'off') ) -%} {{ entity25_icon_color }}
-                {%- elif trigger.entity_id == entity26 and ((trigger.to_state.state == 'on' or trigger.to_state.state == 'open') or (trigger.to_state.entity_id is match "button.") or (trigger.to_state.entity_id is match "input_button.") or (trigger.to_state.entity_id is match "scene.") or (trigger.to_state.entity_id is match "person." and trigger.to_state.state == 'home') or (trigger.to_state.entity_id is match "climate." and trigger.to_state.state != 'off') ) -%} {{ entity26_icon_color }}
-                {%- elif trigger.entity_id == entity27 and ((trigger.to_state.state == 'on' or trigger.to_state.state == 'open') or (trigger.to_state.entity_id is match "button.") or (trigger.to_state.entity_id is match "input_button.") or (trigger.to_state.entity_id is match "scene.") or (trigger.to_state.entity_id is match "person." and trigger.to_state.state == 'home') or (trigger.to_state.entity_id is match "climate." and trigger.to_state.state != 'off') ) -%} {{ entity27_icon_color }}
-                {%- elif trigger.entity_id == entity28 and ((trigger.to_state.state == 'on' or trigger.to_state.state == 'open') or (trigger.to_state.entity_id is match "button.") or (trigger.to_state.entity_id is match "input_button.") or (trigger.to_state.entity_id is match "scene.") or (trigger.to_state.entity_id is match "person." and trigger.to_state.state == 'home') or (trigger.to_state.entity_id is match "climate." and trigger.to_state.state != 'off') ) -%} {{ entity28_icon_color }}
-                {%- elif trigger.entity_id == entity29 and ((trigger.to_state.state == 'on' or trigger.to_state.state == 'open') or (trigger.to_state.entity_id is match "button.") or (trigger.to_state.entity_id is match "input_button.") or (trigger.to_state.entity_id is match "scene.") or (trigger.to_state.entity_id is match "person." and trigger.to_state.state == 'home') or (trigger.to_state.entity_id is match "climate." and trigger.to_state.state != 'off') ) -%} {{ entity29_icon_color }}
-                {%- elif trigger.entity_id == entity30 and ((trigger.to_state.state == 'on' or trigger.to_state.state == 'open') or (trigger.to_state.entity_id is match "button.") or (trigger.to_state.entity_id is match "input_button.") or (trigger.to_state.entity_id is match "scene.") or (trigger.to_state.entity_id is match "person." and trigger.to_state.state == 'home') or (trigger.to_state.entity_id is match "climate." and trigger.to_state.state != 'off') ) -%} {{ entity30_icon_color }}
-                {%- elif trigger.entity_id == entity31 and ((trigger.to_state.state == 'on' or trigger.to_state.state == 'open') or (trigger.to_state.entity_id is match "button.") or (trigger.to_state.entity_id is match "input_button.") or (trigger.to_state.entity_id is match "scene.") or (trigger.to_state.entity_id is match "person." and trigger.to_state.state == 'home') or (trigger.to_state.entity_id is match "climate." and trigger.to_state.state != 'off') ) -%} {{ entity31_icon_color }}
-                {%- elif trigger.entity_id == entity32 and ((trigger.to_state.state == 'on' or trigger.to_state.state == 'open') or (trigger.to_state.entity_id is match "button.") or (trigger.to_state.entity_id is match "input_button.") or (trigger.to_state.entity_id is match "scene.") or (trigger.to_state.entity_id is match "person." and trigger.to_state.state == 'home') or (trigger.to_state.entity_id is match "climate." and trigger.to_state.state != 'off') ) -%} {{ entity32_icon_color }}
-                {%- elif trigger.to_state.state == 'off' or trigger.to_state.state == 'closed' -%} {{ color_03 }}
-                {%- elif trigger.to_state.entity_id is match "person." and trigger.to_state.state != 'home' -%} {{ color_03 }}
-                {%- elif trigger.to_state.entity_id is match "climate." and trigger.to_state.state == 'off' -%} {{ color_03 }}
+                {%- if trigger.entity_id == entity01 and ((trigger.to_state.state == 'on' or trigger.to_state.state == 'open') or (trigger.to_state.entity_id is match "button.") or (trigger.to_state.entity_id is match "input_button.") or (trigger.to_state.entity_id is match "scene.") or (trigger.to_state.entity_id is match "person." and trigger.to_state.state == 'home') or (trigger.to_state.entity_id is match "climate." and trigger.to_state.state != 'off') ) -%} {{ entity01_icon_color | int(65535) }}
+                {%- elif trigger.entity_id == entity02 and ((trigger.to_state.state == 'on' or trigger.to_state.state == 'open') or (trigger.to_state.entity_id is match "button.") or (trigger.to_state.entity_id is match "input_button.") or (trigger.to_state.entity_id is match "scene.") or (trigger.to_state.entity_id is match "person." and trigger.to_state.state == 'home') or (trigger.to_state.entity_id is match "climate." and trigger.to_state.state != 'off') ) -%} {{ entity02_icon_color | int(65535) }}
+                {%- elif trigger.entity_id == entity03 and ((trigger.to_state.state == 'on' or trigger.to_state.state == 'open') or (trigger.to_state.entity_id is match "button.") or (trigger.to_state.entity_id is match "input_button.") or (trigger.to_state.entity_id is match "scene.") or (trigger.to_state.entity_id is match "person." and trigger.to_state.state == 'home') or (trigger.to_state.entity_id is match "climate." and trigger.to_state.state != 'off') ) -%} {{ entity03_icon_color | int(65535) }}
+                {%- elif trigger.entity_id == entity04 and ((trigger.to_state.state == 'on' or trigger.to_state.state == 'open') or (trigger.to_state.entity_id is match "button.") or (trigger.to_state.entity_id is match "input_button.") or (trigger.to_state.entity_id is match "scene.") or (trigger.to_state.entity_id is match "person." and trigger.to_state.state == 'home') or (trigger.to_state.entity_id is match "climate." and trigger.to_state.state != 'off') ) -%} {{ entity04_icon_color | int(65535) }}
+                {%- elif trigger.entity_id == entity05 and ((trigger.to_state.state == 'on' or trigger.to_state.state == 'open') or (trigger.to_state.entity_id is match "button.") or (trigger.to_state.entity_id is match "input_button.") or (trigger.to_state.entity_id is match "scene.") or (trigger.to_state.entity_id is match "person." and trigger.to_state.state == 'home') or (trigger.to_state.entity_id is match "climate." and trigger.to_state.state != 'off') ) -%} {{ entity05_icon_color | int(65535) }}
+                {%- elif trigger.entity_id == entity06 and ((trigger.to_state.state == 'on' or trigger.to_state.state == 'open') or (trigger.to_state.entity_id is match "button.") or (trigger.to_state.entity_id is match "input_button.") or (trigger.to_state.entity_id is match "scene.") or (trigger.to_state.entity_id is match "person." and trigger.to_state.state == 'home') or (trigger.to_state.entity_id is match "climate." and trigger.to_state.state != 'off') ) -%} {{ entity06_icon_color | int(65535) }}
+                {%- elif trigger.entity_id == entity07 and ((trigger.to_state.state == 'on' or trigger.to_state.state == 'open') or (trigger.to_state.entity_id is match "button.") or (trigger.to_state.entity_id is match "input_button.") or (trigger.to_state.entity_id is match "scene.") or (trigger.to_state.entity_id is match "person." and trigger.to_state.state == 'home') or (trigger.to_state.entity_id is match "climate." and trigger.to_state.state != 'off') ) -%} {{ entity07_icon_color | int(65535) }}
+                {%- elif trigger.entity_id == entity08 and ((trigger.to_state.state == 'on' or trigger.to_state.state == 'open') or (trigger.to_state.entity_id is match "button.") or (trigger.to_state.entity_id is match "input_button.") or (trigger.to_state.entity_id is match "scene.") or (trigger.to_state.entity_id is match "person." and trigger.to_state.state == 'home') or (trigger.to_state.entity_id is match "climate." and trigger.to_state.state != 'off') ) -%} {{ entity08_icon_color | int(65535) }}
+                {%- elif trigger.entity_id == entity09 and ((trigger.to_state.state == 'on' or trigger.to_state.state == 'open') or (trigger.to_state.entity_id is match "button.") or (trigger.to_state.entity_id is match "input_button.") or (trigger.to_state.entity_id is match "scene.") or (trigger.to_state.entity_id is match "person." and trigger.to_state.state == 'home') or (trigger.to_state.entity_id is match "climate." and trigger.to_state.state != 'off') ) -%} {{ entity09_icon_color | int(65535) }}
+                {%- elif trigger.entity_id == entity10 and ((trigger.to_state.state == 'on' or trigger.to_state.state == 'open') or (trigger.to_state.entity_id is match "button.") or (trigger.to_state.entity_id is match "input_button.") or (trigger.to_state.entity_id is match "scene.") or (trigger.to_state.entity_id is match "person." and trigger.to_state.state == 'home') or (trigger.to_state.entity_id is match "climate." and trigger.to_state.state != 'off') ) -%} {{ entity10_icon_color | int(65535) }}
+                {%- elif trigger.entity_id == entity11 and ((trigger.to_state.state == 'on' or trigger.to_state.state == 'open') or (trigger.to_state.entity_id is match "button.") or (trigger.to_state.entity_id is match "input_button.") or (trigger.to_state.entity_id is match "scene.") or (trigger.to_state.entity_id is match "person." and trigger.to_state.state == 'home') or (trigger.to_state.entity_id is match "climate." and trigger.to_state.state != 'off') ) -%} {{ entity11_icon_color | int(65535) }}
+                {%- elif trigger.entity_id == entity12 and ((trigger.to_state.state == 'on' or trigger.to_state.state == 'open') or (trigger.to_state.entity_id is match "button.") or (trigger.to_state.entity_id is match "input_button.") or (trigger.to_state.entity_id is match "scene.") or (trigger.to_state.entity_id is match "person." and trigger.to_state.state == 'home') or (trigger.to_state.entity_id is match "climate." and trigger.to_state.state != 'off') ) -%} {{ entity12_icon_color | int(65535) }}
+                {%- elif trigger.entity_id == entity13 and ((trigger.to_state.state == 'on' or trigger.to_state.state == 'open') or (trigger.to_state.entity_id is match "button.") or (trigger.to_state.entity_id is match "input_button.") or (trigger.to_state.entity_id is match "scene.") or (trigger.to_state.entity_id is match "person." and trigger.to_state.state == 'home') or (trigger.to_state.entity_id is match "climate." and trigger.to_state.state != 'off') ) -%} {{ entity13_icon_color | int(65535) }}
+                {%- elif trigger.entity_id == entity14 and ((trigger.to_state.state == 'on' or trigger.to_state.state == 'open') or (trigger.to_state.entity_id is match "button.") or (trigger.to_state.entity_id is match "input_button.") or (trigger.to_state.entity_id is match "scene.") or (trigger.to_state.entity_id is match "person." and trigger.to_state.state == 'home') or (trigger.to_state.entity_id is match "climate." and trigger.to_state.state != 'off') ) -%} {{ entity14_icon_color | int(65535) }}
+                {%- elif trigger.entity_id == entity15 and ((trigger.to_state.state == 'on' or trigger.to_state.state == 'open') or (trigger.to_state.entity_id is match "button.") or (trigger.to_state.entity_id is match "input_button.") or (trigger.to_state.entity_id is match "scene.") or (trigger.to_state.entity_id is match "person." and trigger.to_state.state == 'home') or (trigger.to_state.entity_id is match "climate." and trigger.to_state.state != 'off') ) -%} {{ entity15_icon_color | int(65535) }}
+                {%- elif trigger.entity_id == entity16 and ((trigger.to_state.state == 'on' or trigger.to_state.state == 'open') or (trigger.to_state.entity_id is match "button.") or (trigger.to_state.entity_id is match "input_button.") or (trigger.to_state.entity_id is match "scene.") or (trigger.to_state.entity_id is match "person." and trigger.to_state.state == 'home') or (trigger.to_state.entity_id is match "climate." and trigger.to_state.state != 'off') ) -%} {{ entity16_icon_color | int(65535) }}
+                {%- elif trigger.entity_id == entity17 and ((trigger.to_state.state == 'on' or trigger.to_state.state == 'open') or (trigger.to_state.entity_id is match "button.") or (trigger.to_state.entity_id is match "input_button.") or (trigger.to_state.entity_id is match "scene.") or (trigger.to_state.entity_id is match "person." and trigger.to_state.state == 'home') or (trigger.to_state.entity_id is match "climate." and trigger.to_state.state != 'off') ) -%} {{ entity17_icon_color | int(65535) }}
+                {%- elif trigger.entity_id == entity18 and ((trigger.to_state.state == 'on' or trigger.to_state.state == 'open') or (trigger.to_state.entity_id is match "button.") or (trigger.to_state.entity_id is match "input_button.") or (trigger.to_state.entity_id is match "scene.") or (trigger.to_state.entity_id is match "person." and trigger.to_state.state == 'home') or (trigger.to_state.entity_id is match "climate." and trigger.to_state.state != 'off') ) -%} {{ entity18_icon_color | int(65535) }}
+                {%- elif trigger.entity_id == entity19 and ((trigger.to_state.state == 'on' or trigger.to_state.state == 'open') or (trigger.to_state.entity_id is match "button.") or (trigger.to_state.entity_id is match "input_button.") or (trigger.to_state.entity_id is match "scene.") or (trigger.to_state.entity_id is match "person." and trigger.to_state.state == 'home') or (trigger.to_state.entity_id is match "climate." and trigger.to_state.state != 'off') ) -%} {{ entity19_icon_color | int(65535) }}
+                {%- elif trigger.entity_id == entity20 and ((trigger.to_state.state == 'on' or trigger.to_state.state == 'open') or (trigger.to_state.entity_id is match "button.") or (trigger.to_state.entity_id is match "input_button.") or (trigger.to_state.entity_id is match "scene.") or (trigger.to_state.entity_id is match "person." and trigger.to_state.state == 'home') or (trigger.to_state.entity_id is match "climate." and trigger.to_state.state != 'off') ) -%} {{ entity20_icon_color | int(65535) }}
+                {%- elif trigger.entity_id == entity21 and ((trigger.to_state.state == 'on' or trigger.to_state.state == 'open') or (trigger.to_state.entity_id is match "button.") or (trigger.to_state.entity_id is match "input_button.") or (trigger.to_state.entity_id is match "scene.") or (trigger.to_state.entity_id is match "person." and trigger.to_state.state == 'home') or (trigger.to_state.entity_id is match "climate." and trigger.to_state.state != 'off') ) -%} {{ entity21_icon_color | int(65535) }}
+                {%- elif trigger.entity_id == entity22 and ((trigger.to_state.state == 'on' or trigger.to_state.state == 'open') or (trigger.to_state.entity_id is match "button.") or (trigger.to_state.entity_id is match "input_button.") or (trigger.to_state.entity_id is match "scene.") or (trigger.to_state.entity_id is match "person." and trigger.to_state.state == 'home') or (trigger.to_state.entity_id is match "climate." and trigger.to_state.state != 'off') ) -%} {{ entity22_icon_color | int(65535) }}
+                {%- elif trigger.entity_id == entity23 and ((trigger.to_state.state == 'on' or trigger.to_state.state == 'open') or (trigger.to_state.entity_id is match "button.") or (trigger.to_state.entity_id is match "input_button.") or (trigger.to_state.entity_id is match "scene.") or (trigger.to_state.entity_id is match "person." and trigger.to_state.state == 'home') or (trigger.to_state.entity_id is match "climate." and trigger.to_state.state != 'off') ) -%} {{ entity23_icon_color | int(65535) }}
+                {%- elif trigger.entity_id == entity24 and ((trigger.to_state.state == 'on' or trigger.to_state.state == 'open') or (trigger.to_state.entity_id is match "button.") or (trigger.to_state.entity_id is match "input_button.") or (trigger.to_state.entity_id is match "scene.") or (trigger.to_state.entity_id is match "person." and trigger.to_state.state == 'home') or (trigger.to_state.entity_id is match "climate." and trigger.to_state.state != 'off') ) -%} {{ entity24_icon_color | int(65535) }}
+                {%- elif trigger.entity_id == entity25 and ((trigger.to_state.state == 'on' or trigger.to_state.state == 'open') or (trigger.to_state.entity_id is match "button.") or (trigger.to_state.entity_id is match "input_button.") or (trigger.to_state.entity_id is match "scene.") or (trigger.to_state.entity_id is match "person." and trigger.to_state.state == 'home') or (trigger.to_state.entity_id is match "climate." and trigger.to_state.state != 'off') ) -%} {{ entity25_icon_color | int(65535) }}
+                {%- elif trigger.entity_id == entity26 and ((trigger.to_state.state == 'on' or trigger.to_state.state == 'open') or (trigger.to_state.entity_id is match "button.") or (trigger.to_state.entity_id is match "input_button.") or (trigger.to_state.entity_id is match "scene.") or (trigger.to_state.entity_id is match "person." and trigger.to_state.state == 'home') or (trigger.to_state.entity_id is match "climate." and trigger.to_state.state != 'off') ) -%} {{ entity26_icon_color | int(65535) }}
+                {%- elif trigger.entity_id == entity27 and ((trigger.to_state.state == 'on' or trigger.to_state.state == 'open') or (trigger.to_state.entity_id is match "button.") or (trigger.to_state.entity_id is match "input_button.") or (trigger.to_state.entity_id is match "scene.") or (trigger.to_state.entity_id is match "person." and trigger.to_state.state == 'home') or (trigger.to_state.entity_id is match "climate." and trigger.to_state.state != 'off') ) -%} {{ entity27_icon_color | int(65535) }}
+                {%- elif trigger.entity_id == entity28 and ((trigger.to_state.state == 'on' or trigger.to_state.state == 'open') or (trigger.to_state.entity_id is match "button.") or (trigger.to_state.entity_id is match "input_button.") or (trigger.to_state.entity_id is match "scene.") or (trigger.to_state.entity_id is match "person." and trigger.to_state.state == 'home') or (trigger.to_state.entity_id is match "climate." and trigger.to_state.state != 'off') ) -%} {{ entity28_icon_color | int(65535) }}
+                {%- elif trigger.entity_id == entity29 and ((trigger.to_state.state == 'on' or trigger.to_state.state == 'open') or (trigger.to_state.entity_id is match "button.") or (trigger.to_state.entity_id is match "input_button.") or (trigger.to_state.entity_id is match "scene.") or (trigger.to_state.entity_id is match "person." and trigger.to_state.state == 'home') or (trigger.to_state.entity_id is match "climate." and trigger.to_state.state != 'off') ) -%} {{ entity29_icon_color | int(65535) }}
+                {%- elif trigger.entity_id == entity30 and ((trigger.to_state.state == 'on' or trigger.to_state.state == 'open') or (trigger.to_state.entity_id is match "button.") or (trigger.to_state.entity_id is match "input_button.") or (trigger.to_state.entity_id is match "scene.") or (trigger.to_state.entity_id is match "person." and trigger.to_state.state == 'home') or (trigger.to_state.entity_id is match "climate." and trigger.to_state.state != 'off') ) -%} {{ entity30_icon_color | int(65535) }}
+                {%- elif trigger.entity_id == entity31 and ((trigger.to_state.state == 'on' or trigger.to_state.state == 'open') or (trigger.to_state.entity_id is match "button.") or (trigger.to_state.entity_id is match "input_button.") or (trigger.to_state.entity_id is match "scene.") or (trigger.to_state.entity_id is match "person." and trigger.to_state.state == 'home') or (trigger.to_state.entity_id is match "climate." and trigger.to_state.state != 'off') ) -%} {{ entity31_icon_color | int(65535) }}
+                {%- elif trigger.entity_id == entity32 and ((trigger.to_state.state == 'on' or trigger.to_state.state == 'open') or (trigger.to_state.entity_id is match "button.") or (trigger.to_state.entity_id is match "input_button.") or (trigger.to_state.entity_id is match "scene.") or (trigger.to_state.entity_id is match "person." and trigger.to_state.state == 'home') or (trigger.to_state.entity_id is match "climate." and trigger.to_state.state != 'off') ) -%} {{ entity32_icon_color | int(65535) }}
+                {%- elif trigger.to_state.state == 'off' or trigger.to_state.state == 'closed' -%} {{ nextion_colors.graylight }}
+                {%- elif trigger.to_state.entity_id is match "person." and trigger.to_state.state != 'home' -%} {{ nextion_colors.graylight }}
+                {%- elif trigger.to_state.entity_id is match "climate." and trigger.to_state.state == 'off' -%} {{ nextion_colors.graylight }}
                 {%- endif -%}
 
               # LABEL Font Color
               btn_txt_font: >-
-                {%- if trigger.to_state.entity_id is match "button." or trigger.to_state.entity_id is match "input_button." or trigger.to_state.entity_id is match "scene." -%} {{ color_02 }}
-                {%- elif trigger.to_state.state == 'on' or trigger.to_state.state == 'open' -%} {{ color_02 }}
-                {%- elif trigger.to_state.state == 'off' or trigger.to_state.state == 'closed' -%} {{ color_01 }}
-                {%- elif trigger.to_state.entity_id is match "person." and trigger.to_state.state == 'home' -%} {{ color_02 }}
-                {%- elif trigger.to_state.entity_id is match "person." and trigger.to_state.state != 'home' -%} {{ color_01 }}
-                {%- elif trigger.to_state.entity_id is match "climate." and trigger.to_state.state != 'off' -%} {{ color_02 }}
-                {%- elif trigger.to_state.entity_id is match "climate." and trigger.to_state.state == 'off' -%} {{ color_01 }}
+                {%- if trigger.to_state.entity_id is match "button." or trigger.to_state.entity_id is match "input_button." or trigger.to_state.entity_id is match "scene." -%} {{ nextion_colors.graydark }}
+                {%- elif trigger.to_state.state == 'on' or trigger.to_state.state == 'open' -%} {{ nextion_colors.graydark }}
+                {%- elif trigger.to_state.state == 'off' or trigger.to_state.state == 'closed' -%} {{ nextion_colors.white }}
+                {%- elif trigger.to_state.entity_id is match "person." and trigger.to_state.state == 'home' -%} {{ nextion_colors.graydark }}
+                {%- elif trigger.to_state.entity_id is match "person." and trigger.to_state.state != 'home' -%} {{ nextion_colors.white }}
+                {%- elif trigger.to_state.entity_id is match "climate." and trigger.to_state.state != 'off' -%} {{ nextion_colors.graydark }}
+                {%- elif trigger.to_state.entity_id is match "climate." and trigger.to_state.state == 'off' -%} {{ nextion_colors.white }}
                 {%- endif -%}
               # BRIGHTNESS Font Color
-              btn_bri_font: "{{ color_02 }}"
+              btn_bri_font: "{{ nextion_colors.graydark }}"
               # BRIGHTNESS Value
               btn_bri_txt: >-
                 {%- if trigger.to_state.entity_id is match "light." and trigger.to_state.state == 'on' and trigger.to_state.attributes.brightness is defined -%} {{ (trigger.to_state.attributes.brightness | int * 100 /255) | round(0) }}%
@@ -8252,8 +8503,8 @@ action:
                     {%- elif trigger.to_state.entity_id is match "input_button." -%} {{ button_off }}
                     {%- elif trigger.to_state.entity_id is match "scene." -%} {{ button_off }}
                     {%- endif -%}
-                  btn_bg: '{{ color_02 }}'
-                  btn_txt_font: '{{ color_01 }}'
+                  btn_bg: '{{ nextion_colors.graydark }}'
+                  btn_txt_font: '{{ nextion_colors.white }}'
 
               ##### Button PIC #####
               - service: "{{ command_printf }}"
@@ -8300,7 +8551,7 @@ action:
           #               {%- endif -%}
           #             lightsettings_icon_font_color: >-
           #               {%- if states(entity_long) == 'on' -%} {{ entity_long_icon_color }}
-          #               {%- else -%} {{ color_03 }}
+          #               {%- else -%} {{ nextion_colors.graylight }}
           #               {%- endif -%}
           #         - delay:
           #             milliseconds: "{{ delay_value }}"
@@ -8431,7 +8682,7 @@ action:
           #               {%- endif -%}
           #             coversettings_icon_font_color: >-
           #               {%- if states(entity_long) == 'open' -%} {{ entity_long_icon_color }}
-          #               {%- else -%} {{ color_03 }}
+          #               {%- else -%} {{ nextion_colors.graylight }}
           #               {%- endif -%}
           #         - delay:
           #             milliseconds: "{{ delay_value }}"
@@ -8833,38 +9084,38 @@ action:
 
               ##### Long Press Entity Icon Color #####
               entity_long_icon_color: >-
-                {%- if trigger.to_state.state == "pressbuttonpage01button01" -%} {{ entity01_icon_color }}
-                {%- elif trigger.to_state.state == "pressbuttonpage01button02" -%} {{ entity02_icon_color }}
-                {%- elif trigger.to_state.state == "pressbuttonpage01button03" -%} {{ entity03_icon_color }}
-                {%- elif trigger.to_state.state == "pressbuttonpage01button04" -%} {{ entity04_icon_color }}
-                {%- elif trigger.to_state.state == "pressbuttonpage01button05" -%} {{ entity05_icon_color }}
-                {%- elif trigger.to_state.state == "pressbuttonpage01button06" -%} {{ entity06_icon_color }}
-                {%- elif trigger.to_state.state == "pressbuttonpage01button07" -%} {{ entity07_icon_color }}
-                {%- elif trigger.to_state.state == "pressbuttonpage01button08" -%} {{ entity08_icon_color }}
-                {%- elif trigger.to_state.state == "pressbuttonpage02button01" -%} {{ entity09_icon_color }}
-                {%- elif trigger.to_state.state == "pressbuttonpage02button02" -%} {{ entity10_icon_color }}
-                {%- elif trigger.to_state.state == "pressbuttonpage02button03" -%} {{ entity11_icon_color }}
-                {%- elif trigger.to_state.state == "pressbuttonpage02button04" -%} {{ entity12_icon_color }}
-                {%- elif trigger.to_state.state == "pressbuttonpage02button05" -%} {{ entity13_icon_color }}
-                {%- elif trigger.to_state.state == "pressbuttonpage02button06" -%} {{ entity14_icon_color }}
-                {%- elif trigger.to_state.state == "pressbuttonpage02button07" -%} {{ entity15_icon_color }}
-                {%- elif trigger.to_state.state == "pressbuttonpage02button08" -%} {{ entity16_icon_color }}
-                {%- elif trigger.to_state.state == "pressbuttonpage03button01" -%} {{ entity17_icon_color }}
-                {%- elif trigger.to_state.state == "pressbuttonpage03button02" -%} {{ entity18_icon_color }}
-                {%- elif trigger.to_state.state == "pressbuttonpage03button03" -%} {{ entity19_icon_color }}
-                {%- elif trigger.to_state.state == "pressbuttonpage03button04" -%} {{ entity20_icon_color }}
-                {%- elif trigger.to_state.state == "pressbuttonpage03button05" -%} {{ entity21_icon_color }}
-                {%- elif trigger.to_state.state == "pressbuttonpage03button06" -%} {{ entity22_icon_color }}
-                {%- elif trigger.to_state.state == "pressbuttonpage03button07" -%} {{ entity23_icon_color }}
-                {%- elif trigger.to_state.state == "pressbuttonpage03button08" -%} {{ entity24_icon_color }}
-                {%- elif trigger.to_state.state == "pressbuttonpage04button01" -%} {{ entity25_icon_color }}
-                {%- elif trigger.to_state.state == "pressbuttonpage04button02" -%} {{ entity26_icon_color }}
-                {%- elif trigger.to_state.state == "pressbuttonpage04button03" -%} {{ entity27_icon_color }}
-                {%- elif trigger.to_state.state == "pressbuttonpage04button04" -%} {{ entity28_icon_color }}
-                {%- elif trigger.to_state.state == "pressbuttonpage04button05" -%} {{ entity29_icon_color }}
-                {%- elif trigger.to_state.state == "pressbuttonpage04button06" -%} {{ entity30_icon_color }}
-                {%- elif trigger.to_state.state == "pressbuttonpage04button07" -%} {{ entity31_icon_color }}
-                {%- elif trigger.to_state.state == "pressbuttonpage04button08" -%} {{ entity32_icon_color }}
+                {%- if trigger.to_state.state == "pressbuttonpage01button01" -%} {{ entity01_icon_color | int(65535) }}
+                {%- elif trigger.to_state.state == "pressbuttonpage01button02" -%} {{ entity02_icon_color | int(65535) }}
+                {%- elif trigger.to_state.state == "pressbuttonpage01button03" -%} {{ entity03_icon_color | int(65535) }}
+                {%- elif trigger.to_state.state == "pressbuttonpage01button04" -%} {{ entity04_icon_color | int(65535) }}
+                {%- elif trigger.to_state.state == "pressbuttonpage01button05" -%} {{ entity05_icon_color | int(65535) }}
+                {%- elif trigger.to_state.state == "pressbuttonpage01button06" -%} {{ entity06_icon_color | int(65535) }}
+                {%- elif trigger.to_state.state == "pressbuttonpage01button07" -%} {{ entity07_icon_color | int(65535) }}
+                {%- elif trigger.to_state.state == "pressbuttonpage01button08" -%} {{ entity08_icon_color | int(65535) }}
+                {%- elif trigger.to_state.state == "pressbuttonpage02button01" -%} {{ entity09_icon_color | int(65535) }}
+                {%- elif trigger.to_state.state == "pressbuttonpage02button02" -%} {{ entity10_icon_color | int(65535) }}
+                {%- elif trigger.to_state.state == "pressbuttonpage02button03" -%} {{ entity11_icon_color | int(65535) }}
+                {%- elif trigger.to_state.state == "pressbuttonpage02button04" -%} {{ entity12_icon_color | int(65535) }}
+                {%- elif trigger.to_state.state == "pressbuttonpage02button05" -%} {{ entity13_icon_color | int(65535) }}
+                {%- elif trigger.to_state.state == "pressbuttonpage02button06" -%} {{ entity14_icon_color | int(65535) }}
+                {%- elif trigger.to_state.state == "pressbuttonpage02button07" -%} {{ entity15_icon_color | int(65535) }}
+                {%- elif trigger.to_state.state == "pressbuttonpage02button08" -%} {{ entity16_icon_color | int(65535) }}
+                {%- elif trigger.to_state.state == "pressbuttonpage03button01" -%} {{ entity17_icon_color | int(65535) }}
+                {%- elif trigger.to_state.state == "pressbuttonpage03button02" -%} {{ entity18_icon_color | int(65535) }}
+                {%- elif trigger.to_state.state == "pressbuttonpage03button03" -%} {{ entity19_icon_color | int(65535) }}
+                {%- elif trigger.to_state.state == "pressbuttonpage03button04" -%} {{ entity20_icon_color | int(65535) }}
+                {%- elif trigger.to_state.state == "pressbuttonpage03button05" -%} {{ entity21_icon_color | int(65535) }}
+                {%- elif trigger.to_state.state == "pressbuttonpage03button06" -%} {{ entity22_icon_color | int(65535) }}
+                {%- elif trigger.to_state.state == "pressbuttonpage03button07" -%} {{ entity23_icon_color | int(65535) }}
+                {%- elif trigger.to_state.state == "pressbuttonpage03button08" -%} {{ entity24_icon_color | int(65535) }}
+                {%- elif trigger.to_state.state == "pressbuttonpage04button01" -%} {{ entity25_icon_color | int(65535) }}
+                {%- elif trigger.to_state.state == "pressbuttonpage04button02" -%} {{ entity26_icon_color | int(65535) }}
+                {%- elif trigger.to_state.state == "pressbuttonpage04button03" -%} {{ entity27_icon_color | int(65535) }}
+                {%- elif trigger.to_state.state == "pressbuttonpage04button04" -%} {{ entity28_icon_color | int(65535) }}
+                {%- elif trigger.to_state.state == "pressbuttonpage04button05" -%} {{ entity29_icon_color | int(65535) }}
+                {%- elif trigger.to_state.state == "pressbuttonpage04button06" -%} {{ entity30_icon_color | int(65535) }}
+                {%- elif trigger.to_state.state == "pressbuttonpage04button07" -%} {{ entity31_icon_color | int(65535) }}
+                {%- elif trigger.to_state.state == "pressbuttonpage04button08" -%} {{ entity32_icon_color | int(65535) }}
                 {%- endif -%}
 
 
@@ -9206,7 +9457,7 @@ action:
           - service: "{{ command_font_color }}"
             data:
               component: home.value01_state
-              message: "{{ home_value01_label_color }}"
+              message: "{{ home_value01_label_color | int(65535) }}"
           ### ICON Font ###
           - delay:
               milliseconds: "{{ delay_value }}"
@@ -9228,7 +9479,7 @@ action:
           - service: "{{ command_font_color }}"
             data:
               component: home.value02_state
-              message: "{{ home_value02_label_color }}"
+              message: "{{ home_value02_label_color | int(65535) }}"
           ### ICON Font ###
           - delay:
               milliseconds: "{{ delay_value }}"
@@ -9250,7 +9501,7 @@ action:
           - service: "{{ command_font_color }}"
             data:
               component: home.value03_state
-              message: "{{ home_value03_label_color }}"
+              message: "{{ home_value03_label_color | int(65535) }}"
           ### ICON Font ###
           - delay:
               milliseconds: "{{ delay_value }}"
@@ -9277,7 +9528,7 @@ action:
           - service: "{{ command_font_color }}"
             data:
               component: home.icon_top_01
-              message: "{{ relay01_icon_color }}"
+              message: "{{ relay01_icon_color | int(65535) }}"
           ### ICON Font ###
           - delay:
               milliseconds: "{{ delay_value }}"
@@ -9304,7 +9555,7 @@ action:
           - service: "{{ command_font_color }}"
             data:
               component: home.icon_top_02
-              message: "{{ relay02_icon_color }}"
+              message: "{{ relay02_icon_color | int(65535) }}"
           ### ICON Font ###
           - delay:
               milliseconds: "{{ delay_value }}"
@@ -9332,7 +9583,7 @@ action:
           - service: "{{ command_font_color }}"
             data:
               component: home.icon_top_03
-              message: "{{ thermostat_icon_color }}"
+              message: "{{ thermostat_icon_color | int(65535) }}"
           ### ICON Font ###
           - delay:
               milliseconds: "{{ delay_value }}"
@@ -9359,7 +9610,7 @@ action:
           - service: "{{ command_font_color }}"
             data:
               component: home.icon_top_04
-              message: "{{ chip01_icon_color }}"
+              message: "{{ chip01_icon_color | int(65535) }}"
           ### ICON Font ###
           - delay:
               milliseconds: "{{ delay_value }}"
@@ -9386,7 +9637,7 @@ action:
           - service: "{{ command_font_color }}"
             data:
               component: home.icon_top_05
-              message: "{{ chip02_icon_color }}"
+              message: "{{ chip02_icon_color | int(65535) }}"
           ### ICON Font ###
           - delay:
               milliseconds: "{{ delay_value }}"
@@ -9413,7 +9664,7 @@ action:
           - service: "{{ command_font_color }}"
             data:
               component: home.icon_top_06
-              message: "{{ chip03_icon_color }}"
+              message: "{{ chip03_icon_color | int(65535) }}"
           ### ICON Font ###
           - delay:
               milliseconds: "{{ delay_value }}"
@@ -9440,7 +9691,7 @@ action:
           - service: "{{ command_font_color }}"
             data:
               component: home.icon_top_07
-              message: "{{ chip04_icon_color }}"
+              message: "{{ chip04_icon_color | int(65535) }}"
           ### ICON Font ###
           - delay:
               milliseconds: "{{ delay_value }}"
@@ -9467,7 +9718,7 @@ action:
           - service: "{{ command_font_color }}"
             data:
               component: home.icon_top_08
-              message: "{{ chip05_icon_color }}"
+              message: "{{ chip05_icon_color | int(65535) }}"
           ### ICON Font ###
           - delay:
               milliseconds: "{{ delay_value }}"
@@ -9494,7 +9745,7 @@ action:
           - service: "{{ command_font_color }}"
             data:
               component: home.icon_top_09
-              message: "{{ chip06_icon_color }}"
+              message: "{{ chip06_icon_color | int(65535) }}"
           ### ICON Font ###
           - delay:
               milliseconds: "{{ delay_value }}"
@@ -9521,7 +9772,7 @@ action:
           - service: "{{ command_font_color }}"
             data:
               component: home.icon_top_10
-              message: "{{ chip07_icon_color }}"
+              message: "{{ chip07_icon_color | int(65535) }}"
           ### ICON Font ###
           - delay:
               milliseconds: "{{ delay_value }}"
@@ -9615,7 +9866,7 @@ action:
               set_button04_icon_font: >-
                 {%- if is_state(notification_unread, 'on') and states(notification_text) |length > 0 -%} {{ home_button04_icon_color01 }}
                 {%- elif is_state(notification_unread, 'off') and states(notification_text) |length > 0 -%} {{ home_button04_icon_color02 }}
-                {%- else -%} {{ color_03 }}
+                {%- else -%} {{ nextion_colors.graylight }}
                 {%- endif -%}
           ##### SET ICON Font - Notify #####
           - delay:
@@ -9832,7 +10083,7 @@ action:
           - service: "{{ command_font_color }}"
             data:
               component: home.time
-              message: "{{ time_label_color }}"
+              message: "{{ time_label_color | int(65535) }}"
           ### TIME Font ###
           - service: "{{ command_text_printf }}"
             data:
@@ -9844,7 +10095,7 @@ action:
           - service: "{{ command_font_color }}"
             data:
               component: home.date
-              message: "{{ date_label_color }}"
+              message: "{{ date_label_color | int(65535) }}"
           ### DATE Font ###
           - delay:
               milliseconds: "{{ delay_value }}"
@@ -9866,7 +10117,7 @@ action:
           - service: "{{ command_font_color }}"
             data:
               component: home.outdoor_temp
-              message: "{{ home_outdoor_temp_label_color }}"
+              message: "{{ home_outdoor_temp_label_color | int(65535) }}"
           ### LABEL Outdoor Temp Font ###
           - delay:
               milliseconds: "{{ delay_value }}"
@@ -9888,7 +10139,7 @@ action:
           - service: "{{ command_font_color }}"
             data:
               component: home.current_temp
-              message: "{{ home_indoor_temp_label_color }}"
+              message: "{{ home_indoor_temp_label_color | int(65535) }}"
           ### LABEL Indoor Temp Font ###
           - delay:
               milliseconds: "{{ delay_value }}"
@@ -9914,7 +10165,7 @@ action:
               - service: "{{ command_font_color }}"
                 data:
                   component: home.current_temp
-                  message: "{{ home_indoor_temp_label_color }}"
+                  message: "{{ home_indoor_temp_label_color | int(65535) }}"
               ### LABEL Indoor Temp Font ###
               - delay:
                   milliseconds: "{{ delay_value }}"
@@ -9940,7 +10191,7 @@ action:
               - service: "{{ command_font_color }}"
                 data:
                   component: home.outdoor_temp
-                  message: "{{ home_outdoor_temp_label_color }}"
+                  message: "{{ home_outdoor_temp_label_color | int(65535) }}"
               ### LABEL Outdoor Temp Font ###
               - delay:
                   milliseconds: "{{ delay_value }}"


### PR DESCRIPTION
- Replacing color_xx by nextion_colors.color_name in order to make easier to implement color selection by name instead of rgb565 decimal code. And also makes easier to read the code... ;)

- Added support to css color names, converted (with loss) from RGB888 to RGB565 in addition to the previously used colors. CSS Basic and Extended colors supported: https://www.w3.org/wiki/CSS/Properties/color/keywords

Users will be able to select the colors by name in a drop down instead of typing a color code in RGB565 (which is not very popular). nextion_colors: ## Nextion docs: https://nextion.tech/instruction-set/ (item 5 - Color code constants) black: 0
blue: 1055
brown: 48192
gray: 33840
graydark: 10597
graylight: 33808
graysuperlight: 52857
green: 2016
red: 63488
white: 65535
yellow: 65472