### PR TITLE
Add Home Assistant Icon Page to blueprint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 # Ignore Mac DS_Store files
 .DS_Store
 **/.DS_Store
-.idea

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 # Ignore Mac DS_Store files
 .DS_Store
 **/.DS_Store
+.idea

--- a/nspanel_blueprint.yaml
+++ b/nspanel_blueprint.yaml
@@ -20,6 +20,12 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
 📕 Full documentation and installation is available here [NSPanel Configuration, Setup and HowTo](https://github.com/Blackymas/NSPanel_HA_Blueprint/wiki).
 
 
+🖼️ Home Assistant [Icon Page](https://htmlpreview.github.io/?https://github.com/jobr99/Generate-HASP-Fonts/blob/master/cheatsheet.html)
+
+
+🎨 [Color Converter](https://nodtem66.github.io/nextion-hmi-color-convert/index.html)
+
+
 📌 Step by Step - [Setup Video](https://www.youtube.com/watch?v=3afPFg6kUdc)
 
 


### PR DESCRIPTION
Add the Home Assistnt Icon page to the blueprint to be able to faster find the correct icons.

And a link to the color converter