### PR TITLE
Support to dynamic QR Code

### DIFF
--- a/nspanel_blueprint.yaml
+++ b/nspanel_blueprint.yaml
@@ -521,9 +521,17 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
       selector:
         text: {}
 
+    qrcode_entity:
+      name: QR Code content entity (Optional)
+      description: '* *Page "QRCODE" - Entity containing the value you want to display as QR code (ONLY input_text)*'
+      default: []
+      selector:
+        entity:
+          domain:
+            - input_text
     qrcode_value:
-      name: QR Code content - VALUE (Optional)
-      description: '* *Page "QRCODE" - Value you want to display as QR code*'
+      name: QR Code content - Fallback static value (Optional)
+      description: '* *Page "QRCODE" - Value you want to display as QR code when an entity is not selected or is unavailable*'
       default: []
       selector:
         text: {}
@@ -3028,6 +3036,7 @@ variables:
   indoortemp: !input "indoortemp"
   climate: !input "climate"
   qrcode_label: !input "qrcode_label"
+  qrcode_entity: !input "qrcode_entity"
   qrcode_value: !input "qrcode_value"
   qrcode_enabled: !input "qrcode_enabled"
   relay_1_local_fallback: !input "relay_1_local_fallback"
@@ -4271,6 +4280,14 @@ trigger:
   - platform: template
     value_template: '{{ states(last_click) is match "homebutton05release" }}'
     id: open_qrcode_page
+
+  #### QR Code changed - Trigger ###
+  - platform: state
+    entity_id: !input "qrcode_entity"
+    not_to:
+      - unknown
+      - unavailable
+    id: qrcode_entity_changed
 
   #### Show ENTITIES - Trigger ####
   - platform: template
@@ -7985,7 +8002,7 @@ action:
                   - service: "{{ command_text_printf }}"
                     data:
                       component: "qrcode_value"
-                      message: "{{ qrcode_value }}"
+                      message: "{{ states(qrcode_entity)[0:50] if qrcode_entity and states(qrcode_entity) not in ['unknown', 'unavailable'] else qrcode_value[0:50] }}"
 
               ## PAGE SETTINGS ##
               - conditions: '{{ trigger.event.data.new_state.state == page_settings }}'
@@ -9978,10 +9995,20 @@ action:
             data:
               cmd: home.weather.pic={{ weather_pic }}
 
-
-
 ###########################################################################################################
 
+
+      ##### QR Code entity changed its value while QR Code page is visible #####
+      - conditions:
+          - condition: trigger
+            id: qrcode_entity_changed
+          - condition: template
+            value_template: "{{ states(current_page) == page_qrcode }}"
+        sequence:
+          - service: "{{ command_text_printf }}"
+            data:
+              component: "qrcode_value"
+              message: "{{ states(qrcode_entity)[0:50] if qrcode_entity and states(qrcode_entity) not in ['unknown', 'unavailable'] else qrcode_value[0:50] }}"
 
       ##### Sync Climate ##### -> muss noch in page changed climate wwenn climate page fertig
       - conditions:


### PR DESCRIPTION
- Add support to use an input_text helper to define the QR Code dynamically. In case the entity is unavailable when the QR code is opened, then the user's selected text will be used in the QR Code. (Issue #452)
- Enforce limit to first 50 chars in the QR Code (to preserve memory)

- This add another entry for an input_text entity in the Blueprint setup (QR Code section).
- This change have no impact to users already using a QR code as it will use the existing text as a fallback