### PR TITLE
Fix for slow response with "Loading..."

### DIFF
--- a/nspanel_blueprint.yaml
+++ b/nspanel_blueprint.yaml
@@ -5184,7 +5184,7 @@ action:
                           then:
                             - variables:
                                 ### component_to_update: "{{ repeat.item.button }}"
-                                current_entity_state: "{{ states[repeat.item.entity].state }}"
+                                current_entity_state: "{{ states(repeat.item.entity) }}"
                                 # Button PIC GRAY/WHITE
                                 btn_pic: >-
                                   {%- if current_entity_state == 'unknown' or current_entity_state == 'unavailable' -%} {{ button_off }}
@@ -5435,7 +5435,7 @@ action:
                           then:
                             - variables:
                                 ### component_to_update: "{{ repeat.item.button }}"
-                                current_entity_state: "{{ states[repeat.item.entity].state }}"
+                                current_entity_state: "{{ states(repeat.item.entity) }}"
                                 # Button PIC GRAY/WHITE
                                 btn_pic: >-
                                   {%- if current_entity_state == 'unknown' or current_entity_state == 'unavailable' -%} {{ button_off }}
@@ -5686,7 +5686,7 @@ action:
                           then:
                             - variables:
                                 ### component_to_update: "{{ repeat.item.button }}"
-                                current_entity_state: "{{ states[repeat.item.entity].state }}"
+                                current_entity_state: "{{ states(repeat.item.entity) }}"
                                 # Button PIC GRAY/WHITE
                                 btn_pic: >-
                                   {%- if current_entity_state == 'unknown' or current_entity_state == 'unavailable' -%} {{ button_off }}
@@ -5937,7 +5937,7 @@ action:
                           then:
                             - variables:
                                 ### component_to_update: "{{ repeat.item.button }}"
-                                current_entity_state: "{{ states[repeat.item.entity].state }}"
+                                current_entity_state: "{{ states(repeat.item.entity) }}"
                                 # Button PIC GRAY/WHITE
                                 btn_pic: >-
                                   {%- if current_entity_state == 'unknown' or current_entity_state == 'unavailable' -%} {{ button_off }}


### PR DESCRIPTION
- Fix the error where a missing/invalid entity causes the panel to slow down when opening a new page or keeps with "Loading..." on the screen until it timeouts.

This will probably fix #493