### PR TITLE
Support to date & time formats

### DIFF
--- a/nspanel_blueprint.yaml
+++ b/nspanel_blueprint.yaml
@@ -113,6 +113,35 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
               value: TUR
             - label: 'Ukrainian'
               value: UKR
+    date_format:
+      name: Date Format
+      description: '* *"SYSTEM" - select the format for date to display*'
+      default: '%d.%m'
+      selector:
+        select:
+          multiple: false
+          #mode: dropdown
+          options:
+            - label: 'DD.MM (ex. 22.03)'
+              value: '%d.%m'
+            - label: 'DD/MM (ex. 22/03)'
+              value: '%d/%m'
+            - label: 'D/M (ex. 3/22)'
+              value: '%-m/%-d'
+
+    time_format:
+      name: Time Format
+      description: '* *"SYSTEM" - select the format for time to display*'
+      default: '%H:%M'
+      selector:
+        select:
+          multiple: false
+          #mode: dropdown
+          options:
+            - label: 'HH:MM (ex. 13:30)'
+              value: '%H:%M'
+            - label: 'H:MM AM/PM (ex. 1:30PM)'
+              value: '%-I:%M'
 
     delay:
       name: Delay to avoid synchronization problem
@@ -2331,8 +2360,11 @@ trigger_variables:
 variables:
   ##### GENERAL #####
   blueprint_version: "3.2"
-  time: "{{ (as_timestamp(now()) | timestamp_custom('%H:%M')) }}"
   language: !input "language"
+  date_format: !input "date_format"
+  time_format: !input "time_format"
+  time: "{{ as_timestamp(now()) | timestamp_custom(time_format) }}"
+  meridiem: "{{ as_timestamp(now()) | timestamp_custom('%p') if time_format == '%-I:%M' else '' }}"
 
   notification_sound: "switch.{{ nspanel_name }}_notification_sound"
   confirmation_message: "switch.{{ nspanel_name }}_confirmation_message"
@@ -3455,11 +3487,11 @@ variables:
         heat: нагрів
       please_confirm: Будь ласка, підтвердіть
 
-  mui_weekday_today:     "{{ (dict.values(mui[language].weekdays) | list)[now().weekday()]                       ~ ', ' ~ as_timestamp(now())                     | timestamp_custom('%d.%m') }}"
-  mui_weekday_tomorrow:  "{{ (dict.values(mui[language].weekdays) | list)[(now() + timedelta(days=1)).weekday()] ~ ', ' ~ as_timestamp(now() + timedelta(days=1)) | timestamp_custom('%d.%m') }}"
-  mui_weekday_in_2_days: "{{ (dict.values(mui[language].weekdays) | list)[(now() + timedelta(days=2)).weekday()] ~ ', ' ~ as_timestamp(now() + timedelta(days=2)) | timestamp_custom('%d.%m') }}"
-  mui_weekday_in_3_days: "{{ (dict.values(mui[language].weekdays) | list)[(now() + timedelta(days=3)).weekday()] ~ ', ' ~ as_timestamp(now() + timedelta(days=3)) | timestamp_custom('%d.%m') }}"
-  mui_weekday_in_4_days: "{{ (dict.values(mui[language].weekdays) | list)[(now() + timedelta(days=4)).weekday()] ~ ', ' ~ as_timestamp(now() + timedelta(days=4)) | timestamp_custom('%d.%m') }}"
+  mui_weekday_today:     "{{ (dict.values(mui[language].weekdays) | list)[now().weekday()]                       ~ ', ' ~ as_timestamp(now())                     | timestamp_custom(date_format) }}"
+  mui_weekday_tomorrow:  "{{ (dict.values(mui[language].weekdays) | list)[(now() + timedelta(days=1)).weekday()] ~ ', ' ~ as_timestamp(now() + timedelta(days=1)) | timestamp_custom(date_format) }}"
+  mui_weekday_in_2_days: "{{ (dict.values(mui[language].weekdays) | list)[(now() + timedelta(days=2)).weekday()] ~ ', ' ~ as_timestamp(now() + timedelta(days=2)) | timestamp_custom(date_format) }}"
+  mui_weekday_in_3_days: "{{ (dict.values(mui[language].weekdays) | list)[(now() + timedelta(days=3)).weekday()] ~ ', ' ~ as_timestamp(now() + timedelta(days=3)) | timestamp_custom(date_format) }}"
+  mui_weekday_in_4_days: "{{ (dict.values(mui[language].weekdays) | list)[(now() + timedelta(days=4)).weekday()] ~ ', ' ~ as_timestamp(now() + timedelta(days=4)) | timestamp_custom(date_format) }}"
   #heat_mui: "{{ mui[language].climate.heat }}"
 
   ##### FORCAST ACCUWEATHER - DAY 0 #####
@@ -4179,6 +4211,20 @@ action:
                     data:
                       component: home.time
                       message: "{{ time }}"
+                  ### TIME Meridiem Font Color ###
+                  - delay:
+                      milliseconds: "{{ delay_value }}"
+                  - service: "{{ command_font_color }}"
+                    data:
+                      component: home.meridiem
+                      message: "{{ time_label_color }}"
+                  ### TIME Meridiem Font ###
+                  - delay:
+                      milliseconds: "{{ delay_value }}"
+                  - service: "{{ command_text_printf }}"
+                    data:
+                      component: home.meridiem
+                      message: "{{ meridiem }}"
 
                   ##### NSPanel Outdoor Temp #####
                   - variables:
@@ -9314,6 +9360,21 @@ action:
             data:
               component: home.time
               message: "{{ time }}"
+          ### TIME Meridiem Font Color ###
+          - delay:
+              milliseconds: "{{ delay_value }}"
+          - service: "{{ command_font_color }}"
+            data:
+              component: home.meridiem
+              message: "{{ time_label_color }}"
+          ### TIME Meridiem Font ###
+          - delay:
+              milliseconds: "{{ delay_value }}"
+          - service: "{{ command_text_printf }}"
+            data:
+              component: home.meridiem
+              message: "{{ meridiem }}"
+
           ### DATE Font Color ###
           - delay:
               milliseconds: "{{ delay_value }}"


### PR DESCRIPTION
This add the support to user selected date and time formats. The following formats are supported now:
- Date formats:
  - EU: 22.03
  - UK: 22/03
  - US: 3/22
- Time formats:
  - EU/UK: 13:30
  - US: 1:30 AM/PM (the AM7PM info will be depending on updates on TFT file)

This is a solution for #415 