### PR TITLE
Fix for "Error rendering data template"

### DIFF
--- a/nspanel_blueprint.yaml
+++ b/nspanel_blueprint.yaml
@@ -4518,7 +4518,12 @@ action:
                             - service: "{{ command_text_printf }}"
                               data:
                                 component: "{{ repeat.item.row }}_state"
-                                message: '{{ states(repeat.item.entity) |round(1) }}{{ state_attr(repeat.item.entity, "unit_of_measurement") }}'
+                                message: >
+                                  {% if is_number(states(repeat.item.entity)) %}
+                                    {{ states(repeat.item.entity) | round(1) }}{{ state_attr(repeat.item.entity, "unit_of_measurement") if state_attr(repeat.item.entity, "unit_of_measurement") else '' }}
+                                  {% else %}
+                                    {{ states(repeat.item.entity) | default('unknown') }}
+                                  {% endif %}
 
                   ##### Set notify icon #####
                   - variables:


### PR DESCRIPTION
This fix the following error which happens when an entity with a non-numeric value ('unknown', 'unavailable', some text, etc.) is sent to the device:

```
Error: Error rendering data template: ValueError: Template error: round got invalid input 'Geen' when rendering template '{{ states(repeat.item.entity) |round(1) }}{{ state_attr(repeat.item.entity, "unit_of_measurement") }}' but no default was specified
```
This may also implement the feature requested in #490