### PR TITLE
Fix for warning "list object has no element n"

### DIFF
--- a/nspanel_blueprint.yaml
+++ b/nspanel_blueprint.yaml
@@ -4092,23 +4092,23 @@ action:
         {%- else -%} unknown
         {%- endif -%}
       entity_long: >-
-        {%- if settings_entity_value != "unknown" -%} {{ settings_entity_value.split(',')[0] }}
+        {%- if settings_entity_value != "unknown" and settings_entity_value.split(',') | count >= 1 -%} {{ settings_entity_value.split(',')[0] }}
         {%- else -%} unknown
         {%- endif -%}
       entity_back: >-
-        {%- if settings_entity_value != "unknown" and settings_entity_value.split(',') | count >= 1 -%} {{ settings_entity_value.split(',')[1] }}
+        {%- if settings_entity_value != "unknown" and settings_entity_value.split(',') | count >= 2 -%} {{ settings_entity_value.split(',')[1] }}
         {%- else -%} unknown
         {%- endif -%}
       entity_long_name: >-
-        {%- if settings_entity_value != "unknown" and settings_entity_value.split(',') | count >= 2 -%} {{ settings_entity_value.split(',')[2] }}
+        {%- if settings_entity_value != "unknown" and settings_entity_value.split(',') | count >= 3 -%} {{ settings_entity_value.split(',')[2] }}
         {%- else -%} unknown
         {%- endif -%}
       entity_long_icon: >-
-        {%- if settings_entity_value != "unknown" and settings_entity_value.split(',') | count >= 3 -%} {{ settings_entity_value.split(',')[3] }}
+        {%- if settings_entity_value != "unknown" and settings_entity_value.split(',') | count >= 4 -%} {{ settings_entity_value.split(',')[3] }}
         {%- else -%} unknown
         {%- endif -%}
       entity_long_icon_color: >-
-        {%- if settings_entity_value != "unknown" and settings_entity_value.split(',') | count >= 4 -%} {{ settings_entity_value.split(',')[4] }}
+        {%- if settings_entity_value != "unknown" and settings_entity_value.split(',') | count >= 5 -%} {{ settings_entity_value.split(',')[4] }}
         {%- else -%} unknown
         {%- endif -%}
 


### PR DESCRIPTION
Fix for the following error happening when opening climate page (and maybe other pages also):
```
Template variable warning: list object has no element 3 when rendering '{%- if settings_entity_value != "unknown" and settings_entity_value.split(',') | count >= 3 -%} {{ settings_entity_value.split(',')[3] }} {%- else -%} unknown {%- endif -%}'
```
