### PR TITLE
Add support to `input_boolean` to chips

### DIFF
--- a/nspanel_blueprint.yaml
+++ b/nspanel_blueprint.yaml
@@ -332,8 +332,9 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
         entity:
           domain:
             - binary_sensor
-            - sensor
+            - input_boolean
             - light
+            - sensor
             - switch
     chip01_icon:
       name: Chip 01 - ICON (Optional)


### PR DESCRIPTION
- Chips now supports `input_boolean` entities (Toggle Helpers).

This resolves #479.