### PR TITLE
Update clock at the beginning of each minute

### DIFF
--- a/nspanel_blueprint.yaml
+++ b/nspanel_blueprint.yaml
@@ -3651,7 +3651,7 @@ trigger:
 
   ##### Time - Trigger "time_state" #####
   - platform: time_pattern
-    minutes: "/1"
+    seconds: 0
     id: time_state
 
   #### Weather state changed #######


### PR DESCRIPTION
As it is now, using `minutes: "/1"`, the time will update every minute, but that could happen when lots of seconds has passed on that minute, making possible the displayed time to be up to 59s late.
By changing that to `seconds: 0` if forces the update in the same rate, but always in the first second of a minute, keeping the displayed time always updated.