### PR TITLE
fix: corrects date_format

### DIFF
--- a/nspanel_blueprint.yaml
+++ b/nspanel_blueprint.yaml
@@ -129,8 +129,10 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
               value: '%d.%m'
             - label: 'DD/MM (ex. 22/03)'
               value: '%d/%m'
-            - label: 'D/M (ex. 3/22)'
+            - label: 'M/D (ex. 3/22)'
               value: '%-m/%-d'
+            - label: 'D/M (ex. 22/3)'
+              value: '%-d/%-m'
 
     time_format:
       name: Time Format


### PR DESCRIPTION
The label of the dropdown was incorrect.

This is before:
```yaml
- label: 'D/M (ex. 3/22)'
  value: '%-m/%-d'
```

As you can see the example is not according to the label.

I have corrected this and added a new option, this is the two options:
```yaml
- label: 'M/D (ex. 3/22)'
   value: '%-m/%-d'
- label: 'D/M (ex. 22/3)'
   value: '%-d/%-m'
```

In Sweden we use the last of the two, thats why I added it.