### PR TITLE
Add cover battery when not as an attribute

### DIFF
--- a/nspanel_blueprint.yaml
+++ b/nspanel_blueprint.yaml
@@ -4523,13 +4523,25 @@ action:
                       message: "{{ (state_attr(entity_long, 'current_position') | int ) | round(0) }} %"
 
                   ##### COVER Battery ICON Yes / NO #####
-                  - if: "{{ state_attr(entity_long, 'battery') != none }}"
+                  - variables:
+                      battery_level: >
+                        {% if state_attr(entity_long, 'battery') | default('unavailable') not in ['unavailable', 'unknown', None] %}
+                          {{ state_attr(entity_long, 'battery') | default('unavailable') }}
+                        {% elif expand(device_entities(device_id(entity_long))) | selectattr('attributes.device_class', 'defined') | selectattr('attributes.device_class', 'eq', 'battery') | map(attribute='state') | map('float') | list | count > 0 %}
+                          {{ expand(device_entities(device_id(entity_long))) | selectattr('attributes.device_class', 'defined') | selectattr('attributes.device_class', 'eq', 'battery') | map(attribute='state') | map('float') | list | first }}
+                        {% elif states(entity_long | replace('cover.','sensor.') ~ '_battery') | default('unavailable') not in ['unavailable', 'unknown', None] %}
+                          {{ states(entity_long | replace('cover.','sensor.') ~ '_battery') | default('unavailable') }}
+                        {% elif states(entity_long | replace('cover.','sensor.') | replace('cover', 'battery')) | default('unavailable') not in ['unavailable', 'unknown', None] %}
+                          {{ states(entity_long | replace('cover.','sensor.') | replace('cover', 'battery')) | default('unavailable') }}
+                        {% else %} unavailable
+                        {% endif %}
+                  - if: "{{ is_number(battery_level) }}"
                     then:
                       - *delay-default
                       - service: "{{ nextion.commands.text_printf }}"
                         data:
                           component: coversettings.battery_value
-                          message: "{{ (state_attr(entity_long, 'battery') | int ) | round(0) }} %"
+                          message: "{{ battery_level | round(0) }} %"
                       ### ICON Battery Font Color ###
                       - *delay-default
                       - service: "{{ nextion.commands.font_color }}"


### PR DESCRIPTION
- It will try to find a battery sensor withing the same device.

This should fix #153