### PR TITLE
Support for `opening` & `closing` states on buttons

### DIFF
--- a/nspanel_blueprint.yaml
+++ b/nspanel_blueprint.yaml
@@ -4367,25 +4367,25 @@ action:
                                     current_entity_state: "{{ states(repeat.item.entity) | default('unavailable') }}"
                                     current_entity_state_available: "{{ current_entity_state not in ['unknown', 'unavailable', None] }}"
                                     # Button PIC GRAY/WHITE
-                                    btn_pic: "{{ nextion.pics.button.on if current_entity_state in ['on', 'open', 'home'] or (item_domain == 'climate' and current_entity_state != 'off') else nextion.pics.button.off }}"
+                                    btn_pic: "{{ nextion.pics.button.on if current_entity_state in ['on', 'open', 'opening', 'home'] or (item_domain == 'climate' and current_entity_state != 'off') else nextion.pics.button.off }}"
                                     # TEXT, BRIGHTNESS and ICON Background
-                                    btn_bg: "{{ nextion.colors.white if current_entity_state in ['on', 'open', 'home'] or (item_domain == 'climate' and current_entity_state != 'off') else nextion.colors.grey_dark }}"
+                                    btn_bg: "{{ nextion.colors.white if current_entity_state in ['on', 'open', 'opening', 'home'] or (item_domain == 'climate' and current_entity_state != 'off') else nextion.colors.grey_dark }}"
                                     # ICON Font Color
                                     btn_icon_font: >
                                       {% if not current_entity_state_available %} {{ nextion.colors.red }}
-                                      {% elif item_domain in ['button', 'input_button', 'scene'] or current_entity_state in ['off', 'closed'] or (item_domain == 'person' and current_entity_state != 'home') %} {{ nextion.colors.grey_light }}
-                                      {% elif current_entity_state in ['on', 'open', 'home'] or (item_domain == 'climate' and current_entity_state != 'off') %} {{ repeat.item.icon_color_rgb if is_number(repeat.item.icon_color_rgb) else ((repeat.item.icon_color_rgb[0] //(2**3)) *(2**11))+((repeat.item.icon_color_rgb[1] //(2**2)) *(2**5))+(repeat.item.icon_color_rgb[2] //(2**3)) }}
+                                      {% elif item_domain in ['button', 'input_button', 'scene'] or current_entity_state in ['off', 'closed', 'closing'] or (item_domain == 'person' and current_entity_state != 'home') %} {{ nextion.colors.grey_light }}
+                                      {% elif current_entity_state in ['on', 'open', 'opening', 'home'] or (item_domain == 'climate' and current_entity_state != 'off') %} {{ repeat.item.icon_color_rgb if is_number(repeat.item.icon_color_rgb) else ((repeat.item.icon_color_rgb[0] //(2**3)) *(2**11))+((repeat.item.icon_color_rgb[1] //(2**2)) *(2**5))+(repeat.item.icon_color_rgb[2] //(2**3)) }}
                                       {% else %} {{ nextion.colors.red }}
                                       {% endif %}
                                     # LABEL Font Color
                                     btn_txt_font: >-
                                       {% if not current_entity_state_available %} {{ nextion.colors.white }}
-                                      {% elif item_domain in ['button', 'input_button', 'scene'] or current_entity_state in ['off', 'closed'] or (item_domain == 'person' and current_entity_state != 'home') %} {{ nextion.colors.white }}
-                                      {% elif current_entity_state in ['on', 'open', 'home'] or (item_domain == 'climate' and current_entity_state != 'off') %} {{ nextion.colors.grey_dark }}
+                                      {% elif item_domain in ['button', 'input_button', 'scene'] or current_entity_state in ['off', 'closed', 'closing'] or (item_domain == 'person' and current_entity_state != 'home') %} {{ nextion.colors.white }}
+                                      {% elif current_entity_state in ['on', 'open', 'opening', 'home'] or (item_domain == 'climate' and current_entity_state != 'off') %} {{ nextion.colors.grey_dark }}
                                       {% else %} {{ nextion.colors.white }}
                                       {% endif %}
                                     # BRIGHTNESS Font Color
-                                    btn_bri_font: "{{ nextion.colors.grey_dark }}"
+                                    btn_bri_font: "{{ btn_txt_font }}" #"{{ nextion.colors.grey_dark }}"
                                     # ICON Value
                                     btn_icon: "{{ repeat.item.icon if repeat.item.icon | length > 0 else nextion.icons.buttons[repeat.item.entity.split('.')[0] if repeat.item.entity else 'unknown'] }}"
                                     # LABEL Value
@@ -4394,7 +4394,7 @@ action:
                                     btn_bri_txt: >-
                                       {% if not current_entity_state_available %} 0
                                       {% elif item_domain == 'light' and current_entity_state == 'on' and state_attr(repeat.item.entity, 'brightness') != None %} {{ (state_attr(repeat.item.entity, 'brightness') | int * 100 /255) | round(0) }}%
-                                      {% elif item_domain == 'cover' and current_entity_state == 'open' and state_attr(repeat.item.entity, 'current_position') != None %} {{ (state_attr(repeat.item.entity, 'current_position') | int(100)) | round(0) }}%
+                                      {% elif item_domain == 'cover' and current_entity_state in ['open', 'opening', 'closing'] and state_attr(repeat.item.entity, 'current_position') != None %} {{ (state_attr(repeat.item.entity, 'current_position') | int(100)) | round(0) }}%
                                       {% elif item_domain == 'climate' and current_entity_state != 'off' and state_attr(repeat.item.entity, "current_temperature") != None %} {{ (state_attr(repeat.item.entity, "current_temperature") | float) | round(0) }}{{ weather_units.temperature }}
                                       {% else -%} 0
                                       {% endif -%}


### PR DESCRIPTION
- Button pages now displays cover status when is is `opening` or `closing`.

This probably solves #451