### PR TITLE
Removed "Weather integration" selection from setup

### DIFF
--- a/nspanel_blueprint.yaml
+++ b/nspanel_blueprint.yaml
@@ -167,15 +167,6 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
                 options:
                   - Weather and Temp
         ##### PLACEHOLDER ######################################################################
-          weather:
-            name: Weather Integration
-            description: '* *"SYSTEM" - select our Weather Integration*'
-            default: 'Default'
-            selector:
-              select:
-                options:
-                  - Default
-                  - AccuWeather
           weather_entity:
             name: Weather entity from HA
             description: '* *"SYSTEM" - Select your weather entity.*'


### PR DESCRIPTION
The weather integration is now automatically detected by the Blueprint, based on the attributes provided by the integration itself, so an user selection is not needed anymore.