### PR TITLE
Add time format 24h without leading zero

### DIFF
--- a/nspanel_blueprint.yaml
+++ b/nspanel_blueprint.yaml
@@ -142,10 +142,12 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
                 multiple: false
                 #mode: dropdown
                 options:
-                  - label: 'HH:MM (ex. 13:30)'
+                  - label: 'HH:MM (ex. 08:30 and 20:30)'
                     value: '%H:%M'
-                  - label: 'H:MM AM/PM (ex. 1:30PM)'
+                  - label: 'H:MM AM/PM (ex. 8:30AM and 8:30PM)'
                     value: '%-I:%M'
+                  - label: 'H:MM 24H (ex. 8:30 and 20:30)'
+                    value: '%-H:%M'
 
           delay:
             name: Delay to avoid synchronization problem


### PR DESCRIPTION
To be consistent with the new date format added on v3.2.3.

![image](https://user-images.githubusercontent.com/94725493/230309545-1d123b5d-dfda-4d8c-86ea-eb1adcb33622.jpeg)
![image](https://user-images.githubusercontent.com/94725493/230309578-86220d28-13e9-46a7-9d23-5224395d32ff.jpeg)