### PR TITLE
Reduce # of concurrent instances of blueprint

### DIFF
--- a/nspanel_blueprint.yaml
+++ b/nspanel_blueprint.yaml
@@ -2316,7 +2316,7 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
 #############################################################
 
 mode: parallel
-max: 5000
+max: 50
 trace:
   stored_traces: 10
 

--- a/nspanel_blueprint.yaml
+++ b/nspanel_blueprint.yaml
@@ -2743,17 +2743,17 @@ variables:
       relative_day:
         today: Danas
         tomorrow: Sutra
-        in_2_days: za 2 dana
-        in_3_days: za 3 dana
-        in_4_days: za 4 dana
+        in_2_days: Za 2 dana
+        in_3_days: Za 3 dana
+        in_4_days: Za 4 dana
       climate:
         states:
           "on": uključeno
           "off": isključeno
         heat: toplina
       please_confirm: Molim potvrdite
-      unavailable: Unavailable
-      no_name: No name
+      unavailable: Nedostupno
+      no_name: Bez imena
     HUN:
       weekdays:
         mon: Hétfő

--- a/nspanel_blueprint.yaml
+++ b/nspanel_blueprint.yaml
@@ -1643,7 +1643,7 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
               text: {}
           entities_entity01_icon:
             name: Entity 01 - ICON (Optional)
-            description: '* *Page "BUTTONPAGE01" - Icon which should be displayed (if not set, no icon is shown)*'
+            description: '* *Page "ENTITYPAGE01" - Icon which should be displayed (if not set, no icon is shown)*'
             default: []
             selector: *icon-selector
           entities_entity02:
@@ -1660,7 +1660,7 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
               text: {}
           entities_entity02_icon:
             name: Entity 02 - ICON (Optional)
-            description: '* *Page "BUTTONPAGE01" - Icon which should be displayed (if not set, no icon is shown)*'
+            description: '* *Page "ENTITYPAGE01" - Icon which should be displayed (if not set, no icon is shown)*'
             default: []
             selector: *icon-selector
           entities_entity03:
@@ -1677,7 +1677,7 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
               text: {}
           entities_entity03_icon:
             name: Entity 03 - ICON (Optional)
-            description: '* *Page "BUTTONPAGE01" - Icon which should be displayed (if not set, no icon is shown)*'
+            description: '* *Page "ENTITYPAGE01" - Icon which should be displayed (if not set, no icon is shown)*'
             default: []
             selector: *icon-selector
           entities_entity04:
@@ -1694,7 +1694,7 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
               text: {}
           entities_entity04_icon:
             name: Entity 04 - ICON (Optional)
-            description: '* *Page "BUTTONPAGE01" - Icon which should be displayed (if not set, no icon is shown)*'
+            description: '* *Page "ENTITYPAGE01" - Icon which should be displayed (if not set, no icon is shown)*'
             default: []
             selector: *icon-selector
           entities_entity05:
@@ -1711,7 +1711,7 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
               text: {}
           entities_entity05_icon:
             name: Entity 05 - ICON (Optional)
-            description: '* *Page "BUTTONPAGE01" - Icon which should be displayed (if not set, no icon is shown)*'
+            description: '* *Page "ENTITYPAGE01" - Icon which should be displayed (if not set, no icon is shown)*'
             default: []
             selector: *icon-selector
           entities_entity06:
@@ -1728,7 +1728,7 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
               text: {}
           entities_entity06_icon:
             name: Entity 06 - ICON (Optional)
-            description: '* *Page "BUTTONPAGE01" - Icon which should be displayed (if not set, no icon is shown)*'
+            description: '* *Page "ENTITYPAGE01" - Icon which should be displayed (if not set, no icon is shown)*'
             default: []
             selector: *icon-selector
           entities_entity07:
@@ -1745,7 +1745,7 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
               text: {}
           entities_entity07_icon:
             name: Entity 07 - ICON (Optional)
-            description: '* *Page "BUTTONPAGE01" - Icon which should be displayed (if not set, no icon is shown)*'
+            description: '* *Page "ENTITYPAGE01" - Icon which should be displayed (if not set, no icon is shown)*'
             default: []
             selector: *icon-selector
           entities_entity08:
@@ -1762,7 +1762,7 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
               text: {}
           entities_entity08_icon:
             name: Entity 08 - ICON (Optional)
-            description: '* *Page "BUTTONPAGE01" - Icon which should be displayed (if not set, no icon is shown)*'
+            description: '* *Page "ENTITYPAGE01" - Icon which should be displayed (if not set, no icon is shown)*'
             default: []
             selector: *icon-selector
       ##### Entity page 02 - Entities #####
@@ -1790,7 +1790,7 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
               text: {}
           entities_entity09_icon:
             name: Entity 09 - ICON (Optional)
-            description: '* *Page "BUTTONPAGE02" - Icon which should be displayed (if not set, no icon is shown)*'
+            description: '* *Page "ENTITYPAGE02" - Icon which should be displayed (if not set, no icon is shown)*'
             default: []
             selector: *icon-selector
           entities_entity10:
@@ -1807,7 +1807,7 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
               text: {}
           entities_entity10_icon:
             name: Entity 10 - ICON (Optional)
-            description: '* *Page "BUTTONPAGE02" - Icon which should be displayed (if not set, no icon is shown)*'
+            description: '* *Page "ENTITYPAGE02" - Icon which should be displayed (if not set, no icon is shown)*'
             default: []
             selector: *icon-selector
           entities_entity11:
@@ -1824,7 +1824,7 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
               text: {}
           entities_entity11_icon:
             name: Entity 11 - ICON (Optional)
-            description: '* *Page "BUTTONPAGE02" - Icon which should be displayed (if not set, no icon is shown)*'
+            description: '* *Page "ENTITYPAGE02" - Icon which should be displayed (if not set, no icon is shown)*'
             default: []
             selector: *icon-selector
           entities_entity12:
@@ -1841,7 +1841,7 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
               text: {}
           entities_entity12_icon:
             name: Entity 12 - ICON (Optional)
-            description: '* *Page "BUTTONPAGE02" - Icon which should be displayed (if not set, no icon is shown)*'
+            description: '* *Page "ENTITYPAGE02" - Icon which should be displayed (if not set, no icon is shown)*'
             default: []
             selector: *icon-selector
           entities_entity13:
@@ -1858,7 +1858,7 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
               text: {}
           entities_entity13_icon:
             name: Entity 13 - ICON (Optional)
-            description: '* *Page "BUTTONPAGE02" - Icon which should be displayed (if not set, no icon is shown)*'
+            description: '* *Page "ENTITYPAGE02" - Icon which should be displayed (if not set, no icon is shown)*'
             default: []
             selector: *icon-selector
           entities_entity14:
@@ -1875,7 +1875,7 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
               text: {}
           entities_entity14_icon:
             name: Entity 14 - ICON (Optional)
-            description: '* *Page "BUTTONPAGE02" - Icon which should be displayed (if not set, no icon is shown)*'
+            description: '* *Page "ENTITYPAGE02" - Icon which should be displayed (if not set, no icon is shown)*'
             default: []
             selector: *icon-selector
           entities_entity15:
@@ -1892,7 +1892,7 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
               text: {}
           entities_entity15_icon:
             name: Entity 15 - ICON (Optional)
-            description: '* *Page "BUTTONPAGE02" - Icon which should be displayed (if not set, no icon is shown)*'
+            description: '* *Page "ENTITYPAGE02" - Icon which should be displayed (if not set, no icon is shown)*'
             default: []
             selector: *icon-selector
           entities_entity16:
@@ -1909,7 +1909,7 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
               text: {}
           entities_entity16_icon:
             name: Entity 16 - ICON (Optional)
-            description: '* *Page "BUTTONPAGE02" - Icon which should be displayed (if not set, no icon is shown)*'
+            description: '* *Page "ENTITYPAGE02" - Icon which should be displayed (if not set, no icon is shown)*'
             default: []
             selector: *icon-selector
       ##### Entity page 03 - Entities #####
@@ -1937,7 +1937,7 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
               text: {}
           entities_entity17_icon:
             name: Entity 17 - ICON (Optional)
-            description: '* *Page "BUTTONPAGE03" - Icon which should be displayed (if not set, no icon is shown)*'
+            description: '* *Page "ENTITYPAGE03" - Icon which should be displayed (if not set, no icon is shown)*'
             default: []
             selector: *icon-selector
           entities_entity18:
@@ -1954,7 +1954,7 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
               text: {}
           entities_entity18_icon:
             name: Entity 18 - ICON (Optional)
-            description: '* *Page "BUTTONPAGE03" - Icon which should be displayed (if not set, no icon is shown)*'
+            description: '* *Page "ENTITYPAGE03" - Icon which should be displayed (if not set, no icon is shown)*'
             default: []
             selector: *icon-selector
           entities_entity19:
@@ -1971,7 +1971,7 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
               text: {}
           entities_entity19_icon:
             name: Entity 19 - ICON (Optional)
-            description: '* *Page "BUTTONPAGE03" - Icon which should be displayed (if not set, no icon is shown)*'
+            description: '* *Page "ENTITYPAGE03" - Icon which should be displayed (if not set, no icon is shown)*'
             default: []
             selector: *icon-selector
           entities_entity20:
@@ -1988,7 +1988,7 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
               text: {}
           entities_entity20_icon:
             name: Entity 20 - ICON (Optional)
-            description: '* *Page "BUTTONPAGE03" - Icon which should be displayed (if not set, no icon is shown)*'
+            description: '* *Page "ENTITYPAGE03" - Icon which should be displayed (if not set, no icon is shown)*'
             default: []
             selector: *icon-selector
           entities_entity21:
@@ -2005,7 +2005,7 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
               text: {}
           entities_entity21_icon:
             name: Entity 21 - ICON (Optional)
-            description: '* *Page "BUTTONPAGE03" - Icon which should be displayed (if not set, no icon is shown)*'
+            description: '* *Page "ENTITYPAGE03" - Icon which should be displayed (if not set, no icon is shown)*'
             default: []
             selector: *icon-selector
           entities_entity22:
@@ -2022,7 +2022,7 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
               text: {}
           entities_entity22_icon:
             name: Entity 22 - ICON (Optional)
-            description: '* *Page "BUTTONPAGE03" - Icon which should be displayed (if not set, no icon is shown)*'
+            description: '* *Page "ENTITYPAGE03" - Icon which should be displayed (if not set, no icon is shown)*'
             default: []
             selector: *icon-selector
           entities_entity23:
@@ -2039,7 +2039,7 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
               text: {}
           entities_entity23_icon:
             name: Entity 23 - ICON (Optional)
-            description: '* *Page "BUTTONPAGE03" - Icon which should be displayed (if not set, no icon is shown)*'
+            description: '* *Page "ENTITYPAGE03" - Icon which should be displayed (if not set, no icon is shown)*'
             default: []
             selector: *icon-selector
           entities_entity24:
@@ -2056,7 +2056,7 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
               text: {}
           entities_entity24_icon:
             name: Entity 24 - ICON (Optional)
-            description: '* *Page "BUTTONPAGE03" - Icon which should be displayed (if not set, no icon is shown)*'
+            description: '* *Page "ENTITYPAGE03" - Icon which should be displayed (if not set, no icon is shown)*'
             default: []
             selector: *icon-selector
       ##### Entity page 04 - Entities #####
@@ -2084,7 +2084,7 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
               text: {}
           entities_entity25_icon:
             name: Entity 25 - ICON (Optional)
-            description: '* *Page "BUTTONPAGE04" - Icon which should be displayed (if not set, no icon is shown)*'
+            description: '* *Page "ENTITYPAGE04" - Icon which should be displayed (if not set, no icon is shown)*'
             default: []
             selector: *icon-selector
           entities_entity26:
@@ -2101,7 +2101,7 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
               text: {}
           entities_entity26_icon:
             name: Entity 26 - ICON (Optional)
-            description: '* *Page "BUTTONPAGE04" - Icon which should be displayed (if not set, no icon is shown)*'
+            description: '* *Page "ENTITYPAGE04" - Icon which should be displayed (if not set, no icon is shown)*'
             default: []
             selector: *icon-selector
           entities_entity27:
@@ -2118,7 +2118,7 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
               text: {}
           entities_entity27_icon:
             name: Entity 27 - ICON (Optional)
-            description: '* *Page "BUTTONPAGE04" - Icon which should be displayed (if not set, no icon is shown)*'
+            description: '* *Page "ENTITYPAGE04" - Icon which should be displayed (if not set, no icon is shown)*'
             default: []
             selector: *icon-selector
           entities_entity28:
@@ -2135,7 +2135,7 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
               text: {}
           entities_entity28_icon:
             name: Entity 28 - ICON (Optional)
-            description: '* *Page "BUTTONPAGE04" - Icon which should be displayed (if not set, no icon is shown)*'
+            description: '* *Page "ENTITYPAGE04" - Icon which should be displayed (if not set, no icon is shown)*'
             default: []
             selector: *icon-selector
           entities_entity29:
@@ -2152,7 +2152,7 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
               text: {}
           entities_entity29_icon:
             name: Entity 29 - ICON (Optional)
-            description: '* *Page "BUTTONPAGE04" - Icon which should be displayed (if not set, no icon is shown)*'
+            description: '* *Page "ENTITYPAGE04" - Icon which should be displayed (if not set, no icon is shown)*'
             default: []
             selector: *icon-selector
           entities_entity30:
@@ -2169,7 +2169,7 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
               text: {}
           entities_entity30_icon:
             name: Entity 30 - ICON (Optional)
-            description: '* *Page "BUTTONPAGE04" - Icon which should be displayed (if not set, no icon is shown)*'
+            description: '* *Page "ENTITYPAGE04" - Icon which should be displayed (if not set, no icon is shown)*'
             default: []
             selector: *icon-selector
           entities_entity31:
@@ -2186,7 +2186,7 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
               text: {}
           entities_entity31_icon:
             name: Entity 31 - ICON (Optional)
-            description: '* *Page "BUTTONPAGE04" - Icon which should be displayed (if not set, no icon is shown)*'
+            description: '* *Page "ENTITYPAGE04" - Icon which should be displayed (if not set, no icon is shown)*'
             default: []
             selector: *icon-selector
           entities_entity32:
@@ -2203,7 +2203,7 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
               text: {}
           entities_entity32_icon:
             name: Entity 32 - ICON (Optional)
-            description: '* *Page "BUTTONPAGE04" - Icon which should be displayed (if not set, no icon is shown)*'
+            description: '* *Page "ENTITYPAGE04" - Icon which should be displayed (if not set, no icon is shown)*'
             default: []
             selector: *icon-selector
 

--- a/nspanel_blueprint.yaml
+++ b/nspanel_blueprint.yaml
@@ -2748,9 +2748,9 @@ variables:
         in_4_days: Za 4 dana
       climate:
         states:
-          "on": uključeno
-          "off": isključeno
-        heat: toplina
+          "on": Uključeno
+          "off": Isključeno
+        heat: Toplina
       please_confirm: Molim potvrdite
       unavailable: Nedostupno
       no_name: Bez imena


### PR DESCRIPTION
This reduces the number of parallel instances of the blueprint running. I've done several tests and couldn't see more than 10 instances, so I believe if we should limit the concurrent runs and this will probably be an indication of a problem we want to know about.