### PR TITLE
Convert napanel_name to a valid format

### DIFF
--- a/nspanel_blueprint.yaml
+++ b/nspanel_blueprint.yaml
@@ -2325,7 +2325,8 @@ trace:
 #############################################################
 
 trigger_variables:
-  nspanel_name: !input "nspanel_name"
+  nspanel_name_temp: !input "nspanel_name"
+  nspanel_name: "{{ nspanel_name_temp | replace('-','_') | replace(' ','_') | replace('___','_') | replace('__','_') }}"
   last_click: "sensor.{{ nspanel_name }}_last_click"
   last_click_lightsettings: "sensor.{{ nspanel_name }}_last_click_lightsettings"
   last_click_coversettings: "sensor.{{ nspanel_name }}_last_click_coversettings"


### PR DESCRIPTION
This supports users mistyping the NSPanel name in the blueprint settings. One of the most common mistakes is using `-` in the name, instead of `_` and this change will try to replace that when users type the name with this invalid char.