### PR TITLE
Reduce # of concurrent instances of blueprint

### DIFF
--- a/nspanel_blueprint.yaml
+++ b/nspanel_blueprint.yaml
@@ -2316,7 +2316,7 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
 #############################################################
 
 mode: parallel
-max: 5000
+max: 50
 trace:
   stored_traces: 10
 


### PR DESCRIPTION
This reduces the number of parallel instances of the blueprint running. I've done several tests and couldn't see more than 10 instances, so I believe if we should limit the concurrent runs and this will probably be an indication of a problem we want to know about.