### PR TITLE
Update the correct Nextion variable for sleep modus

### DIFF
--- a/nspanel_esphome.yaml
+++ b/nspanel_esphome.yaml
@@ -867,13 +867,13 @@ switch:
       - globals.set:
             id: sleep_modus_global
             value: '0'
-      - lambda:  id(disp1).set_component_value("settings.a02",0);
+      - lambda:  id(disp1).set_component_value("settings.bt1",0);
     on_turn_on:
       - lambda: id(disp1).send_command_printf("home.sleepmodus.val=1");
       - globals.set:
             id: sleep_modus_global
             value: '1'
-      - lambda:  id(disp1).set_component_value("settings.a02",1);
+      - lambda:  id(disp1).set_component_value("settings.bt1",1);
 
   ##### Relay Local control Fallback #####
   - platform: template


### PR DESCRIPTION
Code was updating the wrong (probably old) variable name on the panel, when the "sleep" button is pressed in settings page