### PR TITLE
Change panel selector to built in device selector

### DIFF
--- a/nspanel_blueprint.yaml
+++ b/nspanel_blueprint.yaml
@@ -44,11 +44,14 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
 
     ##### MAIN NAME #####
           nspanel_name:
-            name: ESPhome Node Name
-            description: '* *"SYSTEM" - here you have to enter exactly the same **"device_name"** you entered in the Esphome file*'
-            default: [nspanel_name]
+            name: (REQUIRED) NSPanel device
+            description: '* *"SYSTEM" - Please select the ESPHome device reated to the NSPanel to be controlled by this automation*'
+            default: []
             selector:
-              text: {}
+              device:
+                filter:
+                  - integration: esphome
+                multiple: false
 
     ##### SYSTEM SETTINGS #####
           language:
@@ -2322,16 +2325,20 @@ trace:
 
 trigger_variables:
   nspanel_name_temp: !input "nspanel_name"
-  nspanel_name: "{{ nspanel_name_temp | replace('-','_') | replace(' ','_') | replace('___','_') | replace('__','_') }}"
+  nspanel_entities: "{{ device_entities(nspanel_name_temp) }}"
+  nspanel_name: >
+    {% if nspanel_entities | count > 0 %}{{ (nspanel_entities | selectattr(None, 'search', '_nextion_inited') | list | first).split('.')[1].split('_nextion_inited')[0] }}
+    {% elif nspanel_name_temp is string %}{{ nspanel_name_temp | replace('-','_') | replace(' ','_') | replace('___','_') | replace('__','_') }}
+    {% endif %}
   last_click: "sensor.{{ nspanel_name }}_last_click"
   last_click_lightsettings: "sensor.{{ nspanel_name }}_last_click_lightsettings"
   last_click_coversettings: "sensor.{{ nspanel_name }}_last_click_coversettings"
   last_click_climatesettings: "sensor.{{ nspanel_name }}_last_click_climatesettings"
   left_button: "binary_sensor.{{ nspanel_name }}_left_button"
   right_button: "binary_sensor.{{ nspanel_name }}_right_button"
-  weather_forcast_button: "binary_sensor.{{ nspanel_name }}_weather_forcast"
-  nextion_inited_trigger: "switch.{{ nspanel_name }}_nextion_inited"
-  # current_page: "sensor.{{ nspanel_name }}_current_page"
+  #weather_forcast_button: "binary_sensor.{{ nspanel_name }}_weather_forcast"
+  nextion_inited: "switch.{{ nspanel_name }}_nextion_inited"
+  #current_page: "sensor.{{ nspanel_name }}_current_page"
   current_page: "sensor.{{ nspanel_name }}_currentpage"
   hotwatercharge: !input "hotwatercharge"
   display_target_temperature: "sensor.{{ nspanel_name }}_display_target_temperature"
@@ -3123,7 +3130,11 @@ variables:
       no_name: No name
 
   ##### WEATHER ####
-  weather_entity: !input "weather_entity" # used only during the creation of weather in variables
+  weather_entity_tmp: !input "weather_entity" # used only during the creation of weather in variables
+  weather_entity: >
+    {% if weather_entity_tmp is string and weather_entity_tmp | length > 0 %} {{ weather_entity_tmp }}
+    {% elif states.weather | list | count > 0 %} {{ states.weather | map(attribute='entity_id') | list | first }}
+    {% endif %}
   temperature_units: '°'
 
   ##### Home page #####
@@ -3229,7 +3240,7 @@ trigger:
 
   ##### Reboot - Trigger "nspanel_boot_init" #####
   - platform: template
-    value_template: "{{ is_state(nextion_inited_trigger, 'on') | default(false) if nextion_inited_trigger is string else false }}"
+    value_template: "{{ is_state(nextion_inited, 'on') | default(false) if nextion_inited is string else false }}"
     for:
       seconds: 1
     id: nspanel_boot_init
@@ -3686,7 +3697,7 @@ trigger:
 ##### CLOSE - Trigger #####
 #############################################################
 
-condition: "{{ is_state(nextion_inited_trigger, 'on') | default(false) if nextion_inited_trigger is string else false }}"
+condition: "{{ is_state(nextion_inited, 'on') | default(false) if nextion_inited is string else false }}"
 
 #############################################################
 ##### START - Action #####

--- a/nspanel_blueprint.yaml
+++ b/nspanel_blueprint.yaml
@@ -51,6 +51,7 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
               device:
                 filter:
                   - integration: esphome
+                    model: esp32dev
                 multiple: false
 
     ##### SYSTEM SETTINGS #####

--- a/nspanel_blueprint.yaml
+++ b/nspanel_blueprint.yaml
@@ -242,7 +242,7 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
                   - sensor
           home_value01_icon:
             name: Sensor 01 - ICON (Optional)
-            description: '* *Page "HOME" - Icon which should be displayed (if not set, no icon is shown)*'
+            description: '* *Page "HOME" - Icon which should be displayed (if not set, it would be used an icon from attributes, if available, or no icon is shown)*'
             default: []
             selector: *icon-selector
           home_value01_icon_color:
@@ -265,7 +265,7 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
                   - sensor
           home_value02_icon:
             name: Sensor 02 - ICON (Optional)
-            description: '* *Page "HOME" - Icon which should be displayed (if not set, no icon is shown)*'
+            description: '* *Page "HOME" - Icon which should be displayed (if not set, it would be used an icon from attributes, if available, or no icon is shown)*'
             default: []
             selector: *icon-selector
           home_value02_icon_color:
@@ -288,7 +288,7 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
                   - sensor
           home_value03_icon:
             name: Sensor 03 - ICON (Optional)
-            description: '* *Page "HOME" - Icon which should be displayed (if not set, no icon is shown)*'
+            description: '* *Page "HOME" - Icon which should be displayed (if not set, it would be used an icon from attributes, if available, or no icon is shown)*'
             default: []
             selector: *icon-selector
           home_value03_icon_color:
@@ -1641,7 +1641,7 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
               text: {}
           entities_entity01_icon:
             name: Entity 01 - ICON (Optional)
-            description: '* *Page "ENTITYPAGE01" - Icon which should be displayed (if not set, no icon is shown)*'
+            description: '* *Page "ENTITYPAGE01" - Icon which should be displayed (if not set, it would be used an icon from attributes, if available, or no icon is shown)*'
             default: []
             selector: *icon-selector
           entities_entity02:
@@ -1658,7 +1658,7 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
               text: {}
           entities_entity02_icon:
             name: Entity 02 - ICON (Optional)
-            description: '* *Page "ENTITYPAGE01" - Icon which should be displayed (if not set, no icon is shown)*'
+            description: '* *Page "ENTITYPAGE01" - Icon which should be displayed (if not set, it would be used an icon from attributes, if available, or no icon is shown)*'
             default: []
             selector: *icon-selector
           entities_entity03:
@@ -1675,7 +1675,7 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
               text: {}
           entities_entity03_icon:
             name: Entity 03 - ICON (Optional)
-            description: '* *Page "ENTITYPAGE01" - Icon which should be displayed (if not set, no icon is shown)*'
+            description: '* *Page "ENTITYPAGE01" - Icon which should be displayed (if not set, it would be used an icon from attributes, if available, or no icon is shown)*'
             default: []
             selector: *icon-selector
           entities_entity04:
@@ -1692,7 +1692,7 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
               text: {}
           entities_entity04_icon:
             name: Entity 04 - ICON (Optional)
-            description: '* *Page "ENTITYPAGE01" - Icon which should be displayed (if not set, no icon is shown)*'
+            description: '* *Page "ENTITYPAGE01" - Icon which should be displayed (if not set, it would be used an icon from attributes, if available, or no icon is shown)*'
             default: []
             selector: *icon-selector
           entities_entity05:
@@ -1709,7 +1709,7 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
               text: {}
           entities_entity05_icon:
             name: Entity 05 - ICON (Optional)
-            description: '* *Page "ENTITYPAGE01" - Icon which should be displayed (if not set, no icon is shown)*'
+            description: '* *Page "ENTITYPAGE01" - Icon which should be displayed (if not set, it would be used an icon from attributes, if available, or no icon is shown)*'
             default: []
             selector: *icon-selector
           entities_entity06:
@@ -1726,7 +1726,7 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
               text: {}
           entities_entity06_icon:
             name: Entity 06 - ICON (Optional)
-            description: '* *Page "ENTITYPAGE01" - Icon which should be displayed (if not set, no icon is shown)*'
+            description: '* *Page "ENTITYPAGE01" - Icon which should be displayed (if not set, it would be used an icon from attributes, if available, or no icon is shown)*'
             default: []
             selector: *icon-selector
           entities_entity07:
@@ -1743,7 +1743,7 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
               text: {}
           entities_entity07_icon:
             name: Entity 07 - ICON (Optional)
-            description: '* *Page "ENTITYPAGE01" - Icon which should be displayed (if not set, no icon is shown)*'
+            description: '* *Page "ENTITYPAGE01" - Icon which should be displayed (if not set, it would be used an icon from attributes, if available, or no icon is shown)*'
             default: []
             selector: *icon-selector
           entities_entity08:
@@ -1760,7 +1760,7 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
               text: {}
           entities_entity08_icon:
             name: Entity 08 - ICON (Optional)
-            description: '* *Page "ENTITYPAGE01" - Icon which should be displayed (if not set, no icon is shown)*'
+            description: '* *Page "ENTITYPAGE01" - Icon which should be displayed (if not set, it would be used an icon from attributes, if available, or no icon is shown)*'
             default: []
             selector: *icon-selector
       ##### Entity page 02 - Entities #####
@@ -1788,7 +1788,7 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
               text: {}
           entities_entity09_icon:
             name: Entity 09 - ICON (Optional)
-            description: '* *Page "ENTITYPAGE02" - Icon which should be displayed (if not set, no icon is shown)*'
+            description: '* *Page "ENTITYPAGE02" - Icon which should be displayed (if not set, it would be used an icon from attributes, if available, or no icon is shown)*'
             default: []
             selector: *icon-selector
           entities_entity10:
@@ -1805,7 +1805,7 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
               text: {}
           entities_entity10_icon:
             name: Entity 10 - ICON (Optional)
-            description: '* *Page "ENTITYPAGE02" - Icon which should be displayed (if not set, no icon is shown)*'
+            description: '* *Page "ENTITYPAGE02" - Icon which should be displayed (if not set, it would be used an icon from attributes, if available, or no icon is shown)*'
             default: []
             selector: *icon-selector
           entities_entity11:
@@ -1822,7 +1822,7 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
               text: {}
           entities_entity11_icon:
             name: Entity 11 - ICON (Optional)
-            description: '* *Page "ENTITYPAGE02" - Icon which should be displayed (if not set, no icon is shown)*'
+            description: '* *Page "ENTITYPAGE02" - Icon which should be displayed (if not set, it would be used an icon from attributes, if available, or no icon is shown)*'
             default: []
             selector: *icon-selector
           entities_entity12:
@@ -1839,7 +1839,7 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
               text: {}
           entities_entity12_icon:
             name: Entity 12 - ICON (Optional)
-            description: '* *Page "ENTITYPAGE02" - Icon which should be displayed (if not set, no icon is shown)*'
+            description: '* *Page "ENTITYPAGE02" - Icon which should be displayed (if not set, it would be used an icon from attributes, if available, or no icon is shown)*'
             default: []
             selector: *icon-selector
           entities_entity13:
@@ -1856,7 +1856,7 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
               text: {}
           entities_entity13_icon:
             name: Entity 13 - ICON (Optional)
-            description: '* *Page "ENTITYPAGE02" - Icon which should be displayed (if not set, no icon is shown)*'
+            description: '* *Page "ENTITYPAGE02" - Icon which should be displayed (if not set, it would be used an icon from attributes, if available, or no icon is shown)*'
             default: []
             selector: *icon-selector
           entities_entity14:
@@ -1873,7 +1873,7 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
               text: {}
           entities_entity14_icon:
             name: Entity 14 - ICON (Optional)
-            description: '* *Page "ENTITYPAGE02" - Icon which should be displayed (if not set, no icon is shown)*'
+            description: '* *Page "ENTITYPAGE02" - Icon which should be displayed (if not set, it would be used an icon from attributes, if available, or no icon is shown)*'
             default: []
             selector: *icon-selector
           entities_entity15:
@@ -1890,7 +1890,7 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
               text: {}
           entities_entity15_icon:
             name: Entity 15 - ICON (Optional)
-            description: '* *Page "ENTITYPAGE02" - Icon which should be displayed (if not set, no icon is shown)*'
+            description: '* *Page "ENTITYPAGE02" - Icon which should be displayed (if not set, it would be used an icon from attributes, if available, or no icon is shown)*'
             default: []
             selector: *icon-selector
           entities_entity16:
@@ -1907,7 +1907,7 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
               text: {}
           entities_entity16_icon:
             name: Entity 16 - ICON (Optional)
-            description: '* *Page "ENTITYPAGE02" - Icon which should be displayed (if not set, no icon is shown)*'
+            description: '* *Page "ENTITYPAGE02" - Icon which should be displayed (if not set, it would be used an icon from attributes, if available, or no icon is shown)*'
             default: []
             selector: *icon-selector
       ##### Entity page 03 - Entities #####
@@ -1935,7 +1935,7 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
               text: {}
           entities_entity17_icon:
             name: Entity 17 - ICON (Optional)
-            description: '* *Page "ENTITYPAGE03" - Icon which should be displayed (if not set, no icon is shown)*'
+            description: '* *Page "ENTITYPAGE03" - Icon which should be displayed (if not set, it would be used an icon from attributes, if available, or no icon is shown)*'
             default: []
             selector: *icon-selector
           entities_entity18:
@@ -1952,7 +1952,7 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
               text: {}
           entities_entity18_icon:
             name: Entity 18 - ICON (Optional)
-            description: '* *Page "ENTITYPAGE03" - Icon which should be displayed (if not set, no icon is shown)*'
+            description: '* *Page "ENTITYPAGE03" - Icon which should be displayed (if not set, it would be used an icon from attributes, if available, or no icon is shown)*'
             default: []
             selector: *icon-selector
           entities_entity19:
@@ -1969,7 +1969,7 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
               text: {}
           entities_entity19_icon:
             name: Entity 19 - ICON (Optional)
-            description: '* *Page "ENTITYPAGE03" - Icon which should be displayed (if not set, no icon is shown)*'
+            description: '* *Page "ENTITYPAGE03" - Icon which should be displayed (if not set, it would be used an icon from attributes, if available, or no icon is shown)*'
             default: []
             selector: *icon-selector
           entities_entity20:
@@ -1986,7 +1986,7 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
               text: {}
           entities_entity20_icon:
             name: Entity 20 - ICON (Optional)
-            description: '* *Page "ENTITYPAGE03" - Icon which should be displayed (if not set, no icon is shown)*'
+            description: '* *Page "ENTITYPAGE03" - Icon which should be displayed (if not set, it would be used an icon from attributes, if available, or no icon is shown)*'
             default: []
             selector: *icon-selector
           entities_entity21:
@@ -2003,7 +2003,7 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
               text: {}
           entities_entity21_icon:
             name: Entity 21 - ICON (Optional)
-            description: '* *Page "ENTITYPAGE03" - Icon which should be displayed (if not set, no icon is shown)*'
+            description: '* *Page "ENTITYPAGE03" - Icon which should be displayed (if not set, it would be used an icon from attributes, if available, or no icon is shown)*'
             default: []
             selector: *icon-selector
           entities_entity22:
@@ -2020,7 +2020,7 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
               text: {}
           entities_entity22_icon:
             name: Entity 22 - ICON (Optional)
-            description: '* *Page "ENTITYPAGE03" - Icon which should be displayed (if not set, no icon is shown)*'
+            description: '* *Page "ENTITYPAGE03" - Icon which should be displayed (if not set, it would be used an icon from attributes, if available, or no icon is shown)*'
             default: []
             selector: *icon-selector
           entities_entity23:
@@ -2037,7 +2037,7 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
               text: {}
           entities_entity23_icon:
             name: Entity 23 - ICON (Optional)
-            description: '* *Page "ENTITYPAGE03" - Icon which should be displayed (if not set, no icon is shown)*'
+            description: '* *Page "ENTITYPAGE03" - Icon which should be displayed (if not set, it would be used an icon from attributes, if available, or no icon is shown)*'
             default: []
             selector: *icon-selector
           entities_entity24:
@@ -2054,7 +2054,7 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
               text: {}
           entities_entity24_icon:
             name: Entity 24 - ICON (Optional)
-            description: '* *Page "ENTITYPAGE03" - Icon which should be displayed (if not set, no icon is shown)*'
+            description: '* *Page "ENTITYPAGE03" - Icon which should be displayed (if not set, it would be used an icon from attributes, if available, or no icon is shown)*'
             default: []
             selector: *icon-selector
       ##### Entity page 04 - Entities #####
@@ -2082,7 +2082,7 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
               text: {}
           entities_entity25_icon:
             name: Entity 25 - ICON (Optional)
-            description: '* *Page "ENTITYPAGE04" - Icon which should be displayed (if not set, no icon is shown)*'
+            description: '* *Page "ENTITYPAGE04" - Icon which should be displayed (if not set, it would be used an icon from attributes, if available, or no icon is shown)*'
             default: []
             selector: *icon-selector
           entities_entity26:
@@ -2099,7 +2099,7 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
               text: {}
           entities_entity26_icon:
             name: Entity 26 - ICON (Optional)
-            description: '* *Page "ENTITYPAGE04" - Icon which should be displayed (if not set, no icon is shown)*'
+            description: '* *Page "ENTITYPAGE04" - Icon which should be displayed (if not set, it would be used an icon from attributes, if available, or no icon is shown)*'
             default: []
             selector: *icon-selector
           entities_entity27:
@@ -2116,7 +2116,7 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
               text: {}
           entities_entity27_icon:
             name: Entity 27 - ICON (Optional)
-            description: '* *Page "ENTITYPAGE04" - Icon which should be displayed (if not set, no icon is shown)*'
+            description: '* *Page "ENTITYPAGE04" - Icon which should be displayed (if not set, it would be used an icon from attributes, if available, or no icon is shown)*'
             default: []
             selector: *icon-selector
           entities_entity28:
@@ -2133,7 +2133,7 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
               text: {}
           entities_entity28_icon:
             name: Entity 28 - ICON (Optional)
-            description: '* *Page "ENTITYPAGE04" - Icon which should be displayed (if not set, no icon is shown)*'
+            description: '* *Page "ENTITYPAGE04" - Icon which should be displayed (if not set, it would be used an icon from attributes, if available, or no icon is shown)*'
             default: []
             selector: *icon-selector
           entities_entity29:
@@ -2150,7 +2150,7 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
               text: {}
           entities_entity29_icon:
             name: Entity 29 - ICON (Optional)
-            description: '* *Page "ENTITYPAGE04" - Icon which should be displayed (if not set, no icon is shown)*'
+            description: '* *Page "ENTITYPAGE04" - Icon which should be displayed (if not set, it would be used an icon from attributes, if available, or no icon is shown)*'
             default: []
             selector: *icon-selector
           entities_entity30:
@@ -2167,7 +2167,7 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
               text: {}
           entities_entity30_icon:
             name: Entity 30 - ICON (Optional)
-            description: '* *Page "ENTITYPAGE04" - Icon which should be displayed (if not set, no icon is shown)*'
+            description: '* *Page "ENTITYPAGE04" - Icon which should be displayed (if not set, it would be used an icon from attributes, if available, or no icon is shown)*'
             default: []
             selector: *icon-selector
           entities_entity31:
@@ -2184,7 +2184,7 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
               text: {}
           entities_entity31_icon:
             name: Entity 31 - ICON (Optional)
-            description: '* *Page "ENTITYPAGE04" - Icon which should be displayed (if not set, no icon is shown)*'
+            description: '* *Page "ENTITYPAGE04" - Icon which should be displayed (if not set, it would be used an icon from attributes, if available, or no icon is shown)*'
             default: []
             selector: *icon-selector
           entities_entity32:
@@ -2201,7 +2201,7 @@ The goal was to create a version that allows everyone to use the NSpanel fully l
               text: {}
           entities_entity32_icon:
             name: Entity 32 - ICON (Optional)
-            description: '* *Page "ENTITYPAGE04" - Icon which should be displayed (if not set, no icon is shown)*'
+            description: '* *Page "ENTITYPAGE04" - Icon which should be displayed (if not set, it would be used an icon from attributes, if available, or no icon is shown)*'
             default: []
             selector: *icon-selector
 


### PR DESCRIPTION
1. The blueprint will now ask for user to select the panel from the list of ESPHome devices instead of typing it's name, in order to reduce the chance of an error -> The old name format still supported, so this is not a breaking change.

2. If a weather entity is not provided, the blueprint will pick one weather entity available, if any.