### PR TITLE
fix: button to exit reparse-mode on factory-device

### DIFF
--- a/nspanel_esphome.yaml
+++ b/nspanel_esphome.yaml
@@ -59,10 +59,6 @@ wifi:
 esphome:
   name: ${device_name}
   min_version: 2022.10.2
-  on_boot:
-    priority: 601
-    then:
-      - lambda: id(disp1).send_command_printf("DRAKJHSUYDGBNCJHGJKSHBDN");
 
 ##### TYPE OF ESP BOARD #####
 esp32:
@@ -126,8 +122,23 @@ button:
     id: tft_update
     entity_category: config
     on_press:
+      - switch.turn_off: nextion_init
       - delay: 16ms
       - lambda: id(disp1).upload_tft();
+
+  ##### EXIT REPARSE TFT DISPLAY #####
+  - platform: template
+    name: ${device_name} Exit reparse
+    icon: mdi:file-sync
+    id: tft_reparse_off
+    entity_category: config
+    on_press:
+      - uart.write:
+          id: tf_uart
+          data: "DRAKJHSUYDGBNCJHGJKSHBDN"
+      - uart.write:
+          id: tf_uart
+          data: [0xFF, 0xFF, 0xFF]
 
 ##### START - API CONFIGURATION #####
 api:
@@ -138,6 +149,7 @@ api:
     ##### SERVICE TO UPDATE THE HMI FILE #####
     - service: upload_tft
       then:
+        - switch.turn_off: nextion_init
         - lambda: 'id(disp1)->upload_tft();'
 
     ##### SERVICE TO UPDATE THE TFT FILE from URL #####
@@ -145,6 +157,7 @@ api:
       variables:
         url: string
       then:
+        - switch.turn_off: nextion_init
         - lambda: 'id(disp1)->set_tft_url(url.c_str());'
         - lambda: 'id(disp1)->upload_tft();'
 
@@ -497,18 +510,6 @@ binary_sensor:
     on_click:
       - switch.toggle: sleep_modus
 
-  ##### Hotwater Charge #####
-  # - platform: nextion
-  #   name: ${device_name} Hotwater Charge
-  #   page_id: 6
-  #   component_id: 20
-    # on_click:
-    #   - homeassistant.service:
-    #       service: switch.toggle
-    #       data:
-    #         entity_id: ${ha_hotwater_charge}
-
-
 ##### START - SENSOR CONFIGURATION #####
 sensor:
 
@@ -600,17 +601,6 @@ sensor:
             value: !lambda 'return int(x);'
           # send text field percentage of current_lightslider_val
         - lambda: id(disp1).set_component_text_printf("settings.a04", "%i", id(display_dim_brightness_global));
-
-  ###### Send current page to HA
-  # - platform: nextion
-  #   id: current_page
-  #   name: "${device_name} Current Page"
-  #   variable_name: dp
-  #   update_interval: 1s
-  #   accuracy_decimals: 0
-  #   filters:
-  #     - delta: 1.0
-  #     - lambda: return int(x);
 
 
 ##### START - TEXT SENSOR CONFIGURATION #####
@@ -788,14 +778,6 @@ text_sensor:
 ##### START - SWITCH CONFIGURATION #####
 switch:
 
-  # ##### Restart switch ######
-  # - platform: restart
-  #   name: ${device_name} Restart
-
-  # ##### Restart in safe-mode #####
-  # - platform: safe_mode
-  #   name: ${device_name} Restart (Safe Mode)
-
   ##### global variable to keep track on whether the Nextion display is ready or not. Delays initial info from HA to the display #####
   - platform: template
     name: ${device_name} Nextion inited
@@ -868,13 +850,13 @@ switch:
       - globals.set:
             id: sleep_modus_global
             value: '0'
-      - lambda:  id(disp1).set_component_value("settings.a02",0);
+      - lambda:  id(disp1).set_component_value("settings.bt1",0);
     on_turn_on:
       - lambda: id(disp1).send_command_printf("home.sleepmodus.val=1");
       - globals.set:
             id: sleep_modus_global
             value: '1'
-      - lambda:  id(disp1).set_component_value("settings.a02",1);
+      - lambda:  id(disp1).set_component_value("settings.bt1",1);
 
   ##### Relay Local control Fallback #####
   - platform: template


### PR DESCRIPTION
This fix adds an additional button to exit the reparse-mode on new devices (factory.tft).
It is only required to do the inital-flash of the tft from this repo.