### PR TITLE
Remove unnecessary diagnostic entities

### DIFF
--- a/nspanel_esphome.yaml
+++ b/nspanel_esphome.yaml
@@ -514,11 +514,6 @@ binary_sensor:
 ##### START - SENSOR CONFIGURATION #####
 sensor:
 
-  ##### Uptime #####
-  - platform: uptime
-    name: ${device_name} uptime
-    disabled_by_default: true
-
   ##### WIFI Signal stregth
   - platform: wifi_signal
     name: ${device_name} RSSI
@@ -606,23 +601,6 @@ sensor:
 
 ##### START - TEXT SENSOR CONFIGURATION #####
 text_sensor:
-
-  ##### ESPhome version used to compile the app #####
-  - platform: version
-    name: ${device_name} ESPhome Version
-    disabled_by_default: true
-
-  - platform: wifi_info
-    ip_address:
-      name: ${device_name} IP
-      disabled_by_default: true
-      id: ip_address
-    ssid:
-      name: ${device_name} SSID
-      disabled_by_default: true
-    bssid:
-      name: ${device_name} BSSID
-      disabled_by_default: true
 
   - platform: template
     name: ${device_name} Notification Label


### PR DESCRIPTION
Removed the following sensors:
- uptime
- ESPHome version
- IP
- SSID
- BSSID

Why not free up this memory for other more useful entities?

Users can always add those sensors to their advanced settings if they want.