### PR TITLE
Changes to `nextion_inited` to become a sensor

### DIFF
--- a/nspanel_blueprint.yaml
+++ b/nspanel_blueprint.yaml
@@ -2330,12 +2330,12 @@ trigger_variables:
   nspanel_name_temp: !input 'nspanel_name'
   nspanel_entities: '{{ device_entities(nspanel_name_temp) }}'
   nspanel_name: >
-    {% if nspanel_entities | count > 0 %}{{ (nspanel_entities | selectattr(None, "search", "_nextion_inited") | list | first).split(".")[1].split("_nextion_inited")[0] }}
+    {% if nspanel_entities | count > 0 %}{{ (nspanel_entities | selectattr(None, "search", "_nextion_display") | list | first).split(".")[1].split("_nextion_display")[0] }}
     {% elif nspanel_name_temp is string %}{{ nspanel_name_temp | replace("-","_") | replace(" ","_") | replace("___","_") | replace("__","_") }}
     {% endif %}
   left_button: 'binary_sensor.{{ nspanel_name }}_left_button'
   right_button: 'binary_sensor.{{ nspanel_name }}_right_button'
-  nextion_inited: 'switch.{{ nspanel_name }}_nextion_inited'
+  nextion_inited: 'binary_sensor.{{ nspanel_name }}_nextion_display'
   nspanelevent: 'sensor.{{ nspanel_name }}_nspanel_event'
   hotwatercharge: !input 'hotwatercharge'
   display_target_temperature: 'sensor.{{ nspanel_name }}_display_target_temperature'

--- a/nspanel_esphome.yaml
+++ b/nspanel_esphome.yaml
@@ -133,7 +133,9 @@ button:
     id: tft_update
     entity_category: config
     on_press:
-      - switch.turn_off: nextion_init
+      - binary_sensor.template.publish:
+          id: nextion_init
+          state: false
       - delay: 16ms
       - lambda: id(disp1).upload_tft();
 
@@ -160,7 +162,9 @@ api:
     ##### SERVICE TO UPDATE THE HMI FILE ##############
     - service: upload_tft
       then:
-        - switch.turn_off: nextion_init
+        - binary_sensor.template.publish:
+            id: nextion_init
+            state: false
         - lambda: 'id(disp1)->upload_tft();'
 
     ##### SERVICE TO UPDATE THE TFT FILE from URL #####
@@ -168,7 +172,9 @@ api:
       variables:
         url: string
       then:
-        - switch.turn_off: nextion_init
+        - binary_sensor.template.publish:
+            id: nextion_init
+            state: false
         - lambda: 'id(disp1)->set_tft_url(url.c_str());'
         - lambda: 'id(disp1)->upload_tft();'
 
@@ -186,7 +192,7 @@ api:
         message: string
       then:
         - wait_until:
-            switch.is_on: nextion_init
+            binary_sensor.is_on: nextion_init
         - lambda: 'id(disp1).set_component_text_printf(component.c_str(), "%s", message.c_str());'
 
     ##### Service to send a command "component_value (Dualstate Button)" directly to the display #####
@@ -196,7 +202,7 @@ api:
         message: int
       then:
         - wait_until:
-            switch.is_on: nextion_init
+            binary_sensor.is_on: nextion_init
         - lambda: 'id(disp1).set_component_value(component.c_str(), message);'
 
     ##### Service to send a command "hide componente" directly to the display #####
@@ -205,7 +211,7 @@ api:
         component: string
       then:
         - wait_until:
-            switch.is_on: nextion_init
+            binary_sensor.is_on: nextion_init
         - lambda: 'id(disp1).hide_component(component.c_str());'
 
     ##### Service to send a command "show componente" directly to the display #####
@@ -214,14 +220,14 @@ api:
         component: string
       then:
         - wait_until:
-            switch.is_on: nextion_init
+            binary_sensor.is_on: nextion_init
         - lambda: 'id(disp1).show_component(component.c_str());'
 
     ##### Service to send a command "show ALL componente" directly to the display #####
     - service: send_command_show_all ### unused ###
       then:
         - wait_until:
-            switch.is_on: nextion_init
+            binary_sensor.is_on: nextion_init
         - lambda: 'id(disp1).show_component("255");'
 
     ##### Service to send a command "font color" directly to the display #####
@@ -231,7 +237,7 @@ api:
         message: int
       then:
         - wait_until:
-            switch.is_on: nextion_init
+            binary_sensor.is_on: nextion_init
         - lambda: 'id(disp1).set_component_font_color(component.c_str(), message);'
 
     ##### Service to send a command "background color" directly to the display #####
@@ -241,7 +247,7 @@ api:
         message: int
       then:
         - wait_until:
-            switch.is_on: nextion_init
+            binary_sensor.is_on: nextion_init
         - lambda: 'id(disp1).set_component_background_color(component.c_str(), message);'
 
     ##### Service to show a notification-message on the screen #####
@@ -251,7 +257,7 @@ api:
         text: string
       then:
         - wait_until:
-            switch.is_on: nextion_init
+            binary_sensor.is_on: nextion_init
         - lambda: |-
             id(disp1).send_command_printf("page notification");
             id(disp1).set_component_text_printf("notification.notifi_label", "%s", label.c_str());
@@ -269,7 +275,7 @@ api:
     - service: notification_clear
       then:
         - wait_until:
-            switch.is_on: nextion_init
+            binary_sensor.is_on: nextion_init
         - lambda: |-
             id(notification_label).publish_state("");
             id(notification_text).publish_state("");
@@ -281,7 +287,7 @@ api:
         entity: string
       then:
         - wait_until:
-            switch.is_on: nextion_init
+            binary_sensor.is_on: nextion_init
         - lambda: |-
             id(settings_entity).publish_state(entity.c_str());
 
@@ -300,7 +306,7 @@ api:
         qrdata: string
       then:
         - wait_until:
-            switch.is_on: nextion_init
+            binary_sensor.is_on: nextion_init
         - lambda: |-
             id(disp1).send_command_printf("page qrcode");
             id(disp1).set_component_text_printf("qrcode.qrcode_value", "%s", qrdata.c_str());
@@ -311,7 +317,7 @@ api:
         value: float
       then:
         - wait_until:
-            switch.is_on: nextion_init
+            binary_sensor.is_on: nextion_init
         - lambda: |-
             //ESP_LOGD("nextion", "thermostat sendig value %f", value);
             int v = int(2 * std::min(std::max(value - 13.5, 0.0), 5.0));
@@ -345,7 +351,7 @@ api:
         btn_bri_txt: string
       then:
         - wait_until:
-            switch.is_on: nextion_init
+            binary_sensor.is_on: nextion_init
         - lambda: |-
             // ESP_LOGD("nextion", "set button %s", btn_id.c_str());
             std::string btnicon = btn_id.c_str() + std::string("icon");
@@ -376,7 +382,7 @@ api:
         ent_value: string
       then:
         - wait_until:
-            switch.is_on: nextion_init
+            binary_sensor.is_on: nextion_init
         - lambda: |-
             // ESP_LOGD("nextion", "set entity %s", ent_id.c_str());
             std::string enticon = ent_id.c_str() + std::string("_pic");
@@ -511,6 +517,16 @@ binary_sensor:
     on_click:
       - switch.toggle: sleep_modus
 
+  ##### global variable to keep track on whether the Nextion display is ready or not.
+  ## Delays initial info from HA to the display #####
+  - name: ${device_name} Nextion display
+    id: nextion_init
+    platform: template
+    device_class: connectivity
+    publish_initial_state: true
+    entity_category: diagnostic
+    icon: mdi:tablet-dashboard
+
 ##### START - SENSOR CONFIGURATION #####
 sensor:
 
@@ -560,7 +576,7 @@ sensor:
     #on_value:
     #  then:
     #    - wait_until:
-    #        switch.is_on: nextion_init
+    #        binary_sensor.is_on: nextion_init
     #     - lambda: id(disp1).set_component_text_printf("home.current_temp", "%.1f°", id(temp_nspanel).state); # onboard temp (thermostat temp) to home page.
     #     - lambda: id(disp1).set_component_text_printf("climate.current_temp", "%.1f", id(temp_nspanel).state);
 
@@ -580,7 +596,7 @@ sensor:
     on_value:
       then:
         - wait_until:
-            switch.is_on: nextion_init
+            binary_sensor.is_on: nextion_init
         - number.set:
             id: display_brightness
             value: !lambda 'return int(x);'
@@ -596,7 +612,7 @@ sensor:
     on_value:
       then:
         - wait_until:
-            switch.is_on: nextion_init
+            binary_sensor.is_on: nextion_init
         - number.set:
             id: display_dim_brightness
             value: !lambda 'return int(x);'
@@ -671,15 +687,6 @@ text_sensor:
 
 ##### START - SWITCH CONFIGURATION #####
 switch:
-
-  ##### global variable to keep track on whether the Nextion display is ready or not. Delays initial info from HA to the display #####
-  - name: ${device_name} Nextion inited
-    platform: template
-    id: nextion_init
-    entity_category: config
-    restore_state: false
-    assumed_state: off
-    optimistic: true
 
   ##### Notification unread #####
   - name: ${device_name} Notification unread
@@ -863,9 +870,9 @@ display:
         - lambda: id(disp1).send_command_printf("home.sleepmodus.val=%i", id(sleep_modus_global));
         - lambda: id(disp1).set_component_value("settings.a02", id(sleep_modus_global) == 1);
         - delay: 1s
-        - switch.template.publish:
+        - binary_sensor.template.publish:
             id: nextion_init
-            state: on
+            state: true
 
 ### Script for page_timer
 script:


### PR DESCRIPTION
Changed from `switch` named `Nextion inited` (with entity_id like `switch.xxxx_nextion_inited`) to a `binary_sensor` named `Nextion display` (`binary_sensor.xxxx_nextion_display`). The idea is to avoid users trying to change it's state from Home Assistant (with unknown consequences) and make this entity more clear, improving usability.

![image](https://user-images.githubusercontent.com/94725493/233913825-c3ac7008-3194-40f9-a793-c2dd3117a346.png)
![image](https://user-images.githubusercontent.com/94725493/233913851-27cd2daf-8c20-4c21-9cdc-5b4ad8a8b5bd.png)

