### PR TITLE
Visual feedback for stateless entities (hw button)

### DIFF
--- a/nspanel_blueprint.yaml
+++ b/nspanel_blueprint.yaml
@@ -4558,17 +4558,17 @@ trigger:
     ##### Left Button - State 'left_button_state' #####
     - platform: state
       entity_id: !input 'left_button_entity'
-      to:
-        - "on"
-        - "off"
+      not_to:
+        - unavailable
+        - unknown
       id: left_button_state
 
     ##### Right Button - State 'right_button_state' #####
     - platform: state
       entity_id: !input 'right_button_entity'
-      to:
-        - "on"
-        - "off"
+      not_to:
+        - unavailable
+        - unknown
       id: right_button_state
 
   ##### Trigger - Time #################################################################################################################
@@ -5715,7 +5715,7 @@ action:
                                         - if: '{{ item_domain in ["button","input_button","scene"] and trigger.id is match "current_state_entity" }}'
                                           then:
                                             - delay:
-                                                milliseconds: '1000'
+                                                milliseconds: 800
                                             - service: '{{ nextion.commands.set_button }}'
                                               data:
                                                 btn_id: '{{ repeat.item.page }}.{{ repeat.item.component }}'
@@ -7141,8 +7141,8 @@ action:
               message: '{{ set_button04_icon_font }}'
             continue_on_error: true
 
-      ##### BUTTON - press #####
-      - alias: Button - Press
+      ##### HW BUTTON - press #####
+      - alias: Hardware button - Press
         conditions:
           - condition: trigger
             id:
@@ -7194,14 +7194,19 @@ action:
               - left_button_state
               - right_button_state
           - '{{ nspanel_event.page == nextion.pages.home }}'
+          - '{{ trigger.to_state.state not in ["unavailable", "unknown", "", None] }}'
         sequence:
-          - variables:
-              # Hardware Button PIC
-              current_hardware_button_state: '{{ nextion.pics.hardware.button[trigger.to_state.state] }}'
           ##### SET hardware Button PIC on Home Page ####
           - service: '{{ nextion.commands.printf }}'
             data:
-              cmd: 'home.{{ "left" if trigger.id == "left_button_state" else "right"}}_bt_pic.pic={{ current_hardware_button_state }}'
+              cmd: 'home.{{ "left" if trigger.id == "left_button_state" else "right"}}_bt_pic.pic={{ nextion.pics.hardware.button.off if trigger.to_state.state in ["off", "closed", "closing"] else nextion.pics.hardware.button.on }}'
+            continue_on_error: true
+          - condition: '{{ trigger.to_state.state not in ["off", "closed", "closing", "on", "open", "closed"] }}'
+          - delay:
+              milliseconds: 800
+          - service: '{{ nextion.commands.printf }}'
+            data:
+              cmd: 'home.{{ "left" if trigger.id == "left_button_state" else "right"}}_bt_pic.pic={{ nextion.pics.hardware.button.off }}'
             continue_on_error: true
 
       ##### DATE AND TIME #####


### PR DESCRIPTION
Implement visual feedback for stateless entities (whatever finishes with a state other than `on`, `off`, `open` and `closed`, like scenes, automations, buttons, etc.). This extends https://github.com/Blackymas/NSPanel_HA_Blueprint/commit/b18f2848f497eb465728f7172364909cdb0f64e2 and solves #691.