### PR TITLE
Auto-update entities pages

### DIFF
--- a/nspanel_blueprint.yaml
+++ b/nspanel_blueprint.yaml
@@ -4839,7 +4839,7 @@ action:
             then:
               - service: '{{ nextion.commands.printf }}'
                 data:
-                  cmd: 'page {{ nextion.pages[settings_entity_domain] }}'
+                  cmd: 'page {{ pages[settings_entity_domain] }}'
                 continue_on_error: true
 
       ##### BOOT NSPANEL - boot init #####

--- a/nspanel_blueprint.yaml
+++ b/nspanel_blueprint.yaml
@@ -7057,7 +7057,7 @@ action:
                           else { "page": "unknown", "component": "unknown", "value": "unknown" }
                         }}
                       last_click_button: '{{ button_pages_buttons | selectattr("page", "defined") | selectattr("page", "eq", nspanel_event.page) | selectattr("component", "defined") | selectattr("component", "eq", nspanel_event.component) | list }}'
-                  - condition: '{{ last_click_button | count >= 0 }}'
+                  - condition: '{{ last_click_button | count >= 0 and button_wait.page == nspanel_event.page }}'
                   - if: '{{ not wait.completed }}'
                     then: # Long press
                       - service: '{{ nextion.commands.set_settings_entity }}'

--- a/nspanel_blueprint.yaml
+++ b/nspanel_blueprint.yaml
@@ -3354,6 +3354,33 @@ trigger_variables:
   notification_text: 'sensor.{{ nspanel_name }}_notification_text'
   notification_label: 'sensor.{{ nspanel_name }}_notification_label'
 
+  pages:
+    home: "home"
+    weatherpages:
+      - "weather01"
+      - "weather02"
+      - "weather03"
+      - "weather04"
+      - "weather05"
+    climate: "climate"
+    settings: "settings"
+    boot: "boot"
+    screensaver: "screensaver"
+    light: "lightsettings"
+    cover: "coversettings"
+    buttonpages:
+      - "buttonpage01"
+      - "buttonpage02"
+      - "buttonpage03"
+      - "buttonpage04"
+    notification: "notification"
+    qrcode: "qrcode"
+    entitypages:
+      - "entitypage01"
+      - "entitypage02"
+      - "entitypage03"
+      - "entitypage04"
+
 variables:
   ##### GENERAL #####
   blueprint_version: '3.3'
@@ -4648,6 +4675,155 @@ trigger:
 
 condition:
   - '{{ is_state(nextion_inited, "on") | default(false) if nextion_inited is string else false }}'
+  - condition: or
+    conditions:
+      - alias: Page independent triggers
+        condition: trigger
+        id:
+          - settings_entity
+          - nspanel_boot_init
+          - nspanelevent_changed
+          - automation_reloaded
+          - sleep_mode_state
+          - tft_upload
+          - left_button_press
+          - right_button_press
+      - alias: Home page
+        condition: and
+        conditions:
+          - '{{ pages.home in states(nspanelevent) }}'
+          - condition: trigger
+            id:
+              - chip01_state
+              - chip02_state
+              - chip03_state
+              - chip04_state
+              - chip05_state
+              - chip06_state
+              - chip07_state
+              - home_value01_state
+              - home_value02_state
+              - home_value03_state
+              - relay01_state
+              - relay02_state
+              - climate_state
+              - notification_text_state
+              - notification_unread_state
+              - left_button_state
+              - right_button_state
+              - time_state
+              - outdoortemp_state
+              - indoortemp_state
+              - nspaneltemp_state
+              - weather_state_change
+      - alias: Button page 01
+        condition: and
+        conditions:
+          - '{{ pages.buttonpages[0] in states(nspanelevent) }}'
+          - condition: trigger
+            id:
+              - current_state_entity01
+              - current_state_entity02
+              - current_state_entity03
+              - current_state_entity04
+              - current_state_entity05
+              - current_state_entity06
+              - current_state_entity07
+              - current_state_entity08
+      - alias: Button page 02
+        condition: and
+        conditions:
+          - '{{ pages.buttonpages[1] in states(nspanelevent) }}'
+          - condition: trigger
+            id:
+              - current_state_entity09
+              - current_state_entity10
+              - current_state_entity11
+              - current_state_entity12
+              - current_state_entity13
+              - current_state_entity14
+              - current_state_entity15
+              - current_state_entity16
+      - alias: Button page 03
+        condition: and
+        conditions:
+          - '{{ pages.buttonpages[2] in states(nspanelevent) }}'
+          - condition: trigger
+            id:
+              - current_state_entity17
+              - current_state_entity18
+              - current_state_entity19
+              - current_state_entity20
+              - current_state_entity21
+              - current_state_entity22
+              - current_state_entity23
+              - current_state_entity24
+      - alias: Button page 04
+        condition: and
+        conditions:
+          - '{{ pages.buttonpages[3] in states(nspanelevent) }}'
+          - condition: trigger
+            id:
+              - current_state_entity25
+              - current_state_entity26
+              - current_state_entity27
+              - current_state_entity28
+              - current_state_entity29
+              - current_state_entity30
+              - current_state_entity31
+              - current_state_entity32
+      - alias: Climate page
+        condition: and
+        conditions:
+          - '{{ pages.climate in states(nspanelevent) }}'
+          - condition: trigger
+            id:
+              - climate_state
+              - hotwatercharge_state
+              - hotwatertemp_state
+      - alias: Light, Cover & Climate settings page
+        condition: and
+        conditions:
+          - >
+            {{
+              pages.light in states(nspanelevent) or
+              pages.cover in states(nspanelevent) or
+              pages.climate in states(nspanelevent)
+            }}
+          - condition: trigger
+            id:
+              - current_state_entity01
+              - current_state_entity02
+              - current_state_entity03
+              - current_state_entity04
+              - current_state_entity05
+              - current_state_entity06
+              - current_state_entity07
+              - current_state_entity08
+              - current_state_entity09
+              - current_state_entity10
+              - current_state_entity11
+              - current_state_entity12
+              - current_state_entity13
+              - current_state_entity14
+              - current_state_entity15
+              - current_state_entity16
+              - current_state_entity17
+              - current_state_entity18
+              - current_state_entity19
+              - current_state_entity20
+              - current_state_entity21
+              - current_state_entity22
+              - current_state_entity23
+              - current_state_entity24
+              - current_state_entity25
+              - current_state_entity26
+              - current_state_entity27
+              - current_state_entity28
+              - current_state_entity29
+              - current_state_entity30
+              - current_state_entity31
+              - current_state_entity32
 
 #############################################################
 ##### START - Action #####
@@ -5022,8 +5198,7 @@ action:
                             variables:
                               thermostat_icon: !input 'thermostat_icon' #E50E
                               heat_icon: !input 'heat_icon' #\U0000E50F
-                              climate_state: '{{ states(climate) | default("unavailable") if climate is string else "unavailable" }}'
-                              climate_action: '{{ state_attr(climate, "hvac_action") | default("unavailable") if climate is string else "unavailable"  }}'
+                              climate_action: '{{ state_attr(climate, "hvac_action") | default("unavailable") if climate is string else "unavailable" }}'
                               home_page_status_bar:
                                 - entity: '{{ relay01_entity }}'
                                   icon: !input 'relay01_icon' #E3A5
@@ -5043,7 +5218,7 @@ action:
                                         if climate_action == "heating"
                                         else all_icons[thermostat_icon.split(":")[1]] | default(thermostat_icon if thermostat_icon is string else all_icons.unknown)
                                       )
-                                      if climate_state == "heat"
+                                      if climate is string and is_state(climate, "heat")
                                       else all_icons.blank
                                     }}
                                   icon_color_rgb: !input 'thermostat_icon_color'

--- a/nspanel_blueprint.yaml
+++ b/nspanel_blueprint.yaml
@@ -3453,32 +3453,6 @@ variables:
         wind: "\U0000E59C" #E59C
         gauge: "\U0000E299" #E299
       unknown: '{{ all_icons.unknown }}' #"\U0000E2D5"
-    pages:
-      home: "home"
-      weatherpages:
-        - "weather01"
-        - "weather02"
-        - "weather03"
-        - "weather04"
-        - "weather05"
-      climate: "climate"
-      settings: "settings"
-      boot: "boot"
-      screensaver: "screensaver"
-      light: "lightsettings"
-      cover: "coversettings"
-      buttonpages:
-        - "buttonpage01"
-        - "buttonpage02"
-        - "buttonpage03"
-        - "buttonpage04"
-      notification: "notification"
-      qrcode: "qrcode"
-      entitypages:
-        - "entitypage01"
-        - "entitypage02"
-        - "entitypage03"
-        - "entitypage04"
     pics:
       hvac:
         button:
@@ -4873,7 +4847,7 @@ action:
         conditions:
           - condition: trigger
             id: nspanel_boot_init
-          - '{{ nspanel_event.page != nextion.pages.home or (is_state(settings_entity, ["unavailable", "unknown", "", None]) | default(False) if settings_entity is string else False) }}'
+          - '{{ nspanel_event.page != pages.home or (is_state(settings_entity, ["unavailable", "unknown", "", None]) | default(False) if settings_entity is string else False) }}'
         sequence:
           ##### NSPanel boot init only #####
           - delay:
@@ -4915,7 +4889,7 @@ action:
               milliseconds: '{{ delay_value }}'
           - service: '{{ nextion.commands.printf }}'
             data:
-              cmd: "page {{ nextion.pages.home }}"
+              cmd: "page {{ pages.home }}"
             continue_on_error: true
 
       ##### NSPanel event #####
@@ -4933,7 +4907,7 @@ action:
                     variables:
                       old_state: '{{ trigger.event.data.old_state.state }}'
                   ##### climate-page left - apply climate temperature if climate_optimistic ##### ## TODO - remove from here
-                  - if: '{{ old_state.page == nextion.pages.climate and climate_optimistic }}'
+                  - if: '{{ old_state.page == pages.climate and climate_optimistic }}'
                     then:
                       - variables:
                           display_target_temperature_state: >
@@ -4953,7 +4927,7 @@ action:
                   - choose:
                       ## PAGE HOME ##
                       - alias: Home page
-                        conditions: '{{ nspanel_event.page == nextion.pages.home }}'
+                        conditions: '{{ nspanel_event.page == pages.home }}'
                         sequence: &refresh_page_home
                           - service: '{{ nextion.commands.set_settings_entity }}'
                             data:
@@ -5518,7 +5492,7 @@ action:
 
                       ## BUTTON PAGES 01 - 04 ##
                       - alias: Button pages
-                        conditions: '{{ nspanel_event.page in nextion.pages.buttonpages }}'
+                        conditions: '{{ nspanel_event.page in pages.buttonpages }}'
                         sequence: &refresh_page_buttonpage
                           - &variables-page_buttons
                             variables:
@@ -5918,7 +5892,7 @@ action:
 
                       ## PAGE LIGHTSETTINGS ##
                       - alias: Light settings page
-                        conditions: '{{ nspanel_event.page == nextion.pages.light }}'
+                        conditions: '{{ nspanel_event.page == pages.light }}'
                         sequence: &refresh_page_lightsettings
                           - *variables-settings_entity
                           - if: '{{ settings_entity_domain == "light" }}'
@@ -6019,7 +5993,7 @@ action:
 
                       ## PAGE COVERSETTINGS ##
                       - alias: Cover settings page
-                        conditions: '{{ nspanel_event.page == nextion.pages.cover }}'
+                        conditions: '{{ nspanel_event.page == pages.cover }}'
                         sequence: &refresh_page_coversettings
                           ##### COVER - OPEN / CLOSE #####
                           - *variables-settings_entity
@@ -6125,12 +6099,12 @@ action:
 
                       ## PAGE CLIMATE ##
                       - alias: Climate page
-                        conditions: '{{ nspanel_event.page == nextion.pages.climate }}'
+                        conditions: '{{ nspanel_event.page == pages.climate }}'
                         sequence: &refresh_page_climate
                           - *variables-settings_entity
                           - variables:
                               settings_entity_dict: >
-                                {% if settings_entity_dict.entity is not defined and settings_entity_dict.page == nextion.pages.home and settings_entity_dict.component == 'climate' %}
+                                {% if settings_entity_dict.entity is not defined and settings_entity_dict.page == pages.home and settings_entity_dict.component == 'climate' %}
                                   {
                                     'page': '{{ settings_entity_dict.page }}',
                                     'entity': '{{ climate }}',
@@ -6245,7 +6219,7 @@ action:
 
                       ## ENTITY PAGES 01 - 04 ##
                       - alias: Entity pages
-                        conditions: '{{ nspanel_event.page in nextion.pages.entitypages }}'
+                        conditions: '{{ nspanel_event.page in pages.entitypages }}'
                         sequence: &refresh-entity_pages
                           - &variables-entity_pages
                             variables:
@@ -6461,7 +6435,7 @@ action:
 
                       ## PAGE WEATHER (WEATHER01 to WEATHER05) ##
                       - alias: Weather pages
-                        conditions: '{{ nspanel_event.page in nextion.pages.weatherpages }}'
+                        conditions: '{{ nspanel_event.page in pages.weatherpages }}'
                         sequence:
                           - variables:
                               weather_attribution: '{{ state_attr(weather_entity, "attribution") if weather_entity is string }}'
@@ -6650,7 +6624,7 @@ action:
                                           cmd: >
                                             {{ page_name }}.weather_icon.pic={{
                                               nextion.pics.weather[states(weather_entity) | default("unavailable") if weather_entity is string else "unavailable"] | default(None)
-                                              if condition == "unknown" and page_name == nextion.pages.weatherpages[0]
+                                              if condition == "unknown" and page_name == pages.weatherpages[0]
                                               else nextion.pics.weather[condition] | default(None)
                                             }}
                                         continue_on_error: true
@@ -6698,7 +6672,7 @@ action:
 
                       ## PAGE NOTIFICATION ##
                       - alias: Notification page
-                        conditions: '{{ nspanel_event.page == nextion.pages.notification }}'
+                        conditions: '{{ nspanel_event.page == pages.notification }}'
                         sequence:
                           - service: '{{ nextion.commands.text_printf }}'
                             data:
@@ -6714,7 +6688,7 @@ action:
 
                       ## PAGE QR Code ##
                       - alias: QRCode page
-                        conditions: '{{ nspanel_event.page == nextion.pages.qrcode }}'
+                        conditions: '{{ nspanel_event.page == pages.qrcode }}'
                         sequence:
                           - variables:
                               qrcode_label: !input 'qrcode_label'
@@ -6735,17 +6709,17 @@ action:
 
                       ## PAGE SETTINGS ##
                       #- alias: Settings page
-                      #  conditions: '{{ nspanel_event.page == nextion.pages.settings }}'
+                      #  conditions: '{{ nspanel_event.page == pages.settings }}'
                       #  sequence:
 
                       ## PAGE BOOT ##
                       #- alias: Boot page
-                      #  conditions: '{{ nspanel_event.page == nextion.pages.boot }}'
+                      #  conditions: '{{ nspanel_event.page == pages.boot }}'
                       #  sequence:
 
                       ## PAGE SCREENSAVER ##
                       #- alias: Screensaver page
-                      #  conditions: '{{ nspanel_event.page == nextion.pages.screensaver }}'
+                      #  conditions: '{{ nspanel_event.page == pages.screensaver }}'
                       #  sequence:
 
               - alias: Page close # general
@@ -6754,7 +6728,7 @@ action:
                   - *variables-settings_entity
                   - service: '{{ nextion.commands.printf }}'
                     data:
-                      cmd: 'page {{ settings_entity_dict.page if settings_entity_dict.page is defined else nextion.pages.home }}'
+                      cmd: 'page {{ settings_entity_dict.page if settings_entity_dict.page is defined else pages.home }}'
                     continue_on_error: true
 
               - alias: lightsetting # rgb_color, brightness, color_temp
@@ -6870,7 +6844,7 @@ action:
 
               - alias: Button page - Button press
                 conditions:
-                  - '{{ nspanel_event.page in nextion.pages.buttonpages }}'
+                  - '{{ nspanel_event.page in pages.buttonpages }}'
                   - '{{ nspanel_event.value == "press" }}'
                 sequence:
                   - wait_template: >
@@ -6938,7 +6912,7 @@ action:
                                 continue_on_error: true
                               - service: '{{ nextion.commands.printf }}'
                                 data:
-                                  cmd: 'page {{ nextion.pages.notification }}'
+                                  cmd: 'page {{ pages.notification }}'
                                 continue_on_error: true
                               - service: '{{ nextion.commands.text_printf }}'
                                 data:
@@ -7016,14 +6990,14 @@ action:
                                     continue_on_error: true
                                   - service: '{{ nextion.commands.printf }}'
                                     data:
-                                      cmd: 'page {{ nextion.pages.home }}'
+                                      cmd: 'page {{ pages.home }}'
                                     continue_on_error: true
                             else:
                               - *service-button_changed
 
               - alias: Jump to climate page
                 conditions:
-                  - '{{ nspanel_event.page == nextion.pages.home }} '
+                  - '{{ nspanel_event.page == pages.home }} '
                   - '{{ nspanel_event.component == "climate" }}'
                   - '{{ nspanel_event.value == "release" }}'
                   - '{{ climate | length > 0 }} '
@@ -7035,50 +7009,50 @@ action:
 
               - alias: Jump to weather page
                 conditions:
-                  - '{{ nspanel_event.page == nextion.pages.home }}'
+                  - '{{ nspanel_event.page == pages.home }}'
                   - '{{ nspanel_event.component == "weather" }}'
                 sequence:
                   - service: '{{ nextion.commands.printf }}'
                     data:
-                      cmd: 'page {{ nextion.pages.weatherpages[0] }}'
+                      cmd: 'page {{ pages.weatherpages[0] }}'
                     continue_on_error: true
 
               - alias: Jump to QR code page
                 conditions:
                   - '{{ qrcode_enabled == true }}'
-                  - '{{ nspanel_event.page == nextion.pages.home }}'
+                  - '{{ nspanel_event.page == pages.home }}'
                   - '{{ nspanel_event.component == "button05" }}'
                 sequence:
                   - service: '{{ nextion.commands.printf }}'
                     data:
-                      cmd: 'page {{ nextion.pages.qrcode }}'
+                      cmd: 'page {{ pages.qrcode }}'
                     continue_on_error: true
 
               - alias: Jump to entity page
                 conditions:
                   - '{{ entitypages_enabled == true }}'
-                  - '{{ nspanel_event.page == nextion.pages.home }}'
+                  - '{{ nspanel_event.page == pages.home }}'
                   - '{{ nspanel_event.component == "button06" }}'
                 sequence:
                   - service: '{{ nextion.commands.printf }}'
                     data:
-                      cmd: 'page {{ nextion.pages.entitypages[0] }}'
+                      cmd: 'page {{ pages.entitypages[0] }}'
                     continue_on_error: true
 
               - alias: Jump to notification page
                 conditions:
-                  - '{{ nspanel_event.page == nextion.pages.home }}'
+                  - '{{ nspanel_event.page == pages.home }}'
                   - '{{ nspanel_event.component == "button04" }}'
                   - '{{ notification_text is string and states(notification_text) | length > 0 }}'
                 sequence:
                   - service: '{{ nextion.commands.printf }}'
                     data:
-                      cmd: 'page {{ nextion.pages.notification }}'
+                      cmd: 'page {{ pages.notification }}'
                     continue_on_error: true
 
               - alias: Show button - Notification clear
                 conditions:
-                  - '{{ nspanel_event.page == nextion.pages.notification }}'
+                  - '{{ nspanel_event.page == pages.notification }}'
                   - '{{ nspanel_event.component == "clear" }}'
                   - '{{ confirmation_message is string and states(confirmation_message) | default("unavailable") != "on" }}'
                 sequence:
@@ -7088,12 +7062,12 @@ action:
                     continue_on_error: true
                   - service: '{{ nextion.commands.printf }}'
                     data:
-                      cmd: 'page {{ nextion.pages.home }}'
+                      cmd: 'page {{ pages.home }}'
                     continue_on_error: true
 
               - alias: Show button - Notification accept
                 conditions:
-                  - '{{ nspanel_event.page == nextion.pages.notification }}'
+                  - '{{ nspanel_event.page == pages.notification }}'
                   - '{{ nspanel_event.component == "accept" }}'
                   - '{{ confirmation_message is string and states(confirmation_message) | default("unavailable") != "on" }}'
                 sequence:
@@ -7106,7 +7080,7 @@ action:
                     continue_on_error: true
                   - service: '{{ nextion.commands.printf }}'
                     data:
-                      cmd: 'page {{ nextion.pages.home }}'
+                      cmd: 'page {{ pages.home }}'
                     continue_on_error: true
 
 
@@ -7118,15 +7092,15 @@ action:
         sequence:
           - choose:
               ## PAGE HOME ##
-              - conditions: '{{ nspanel_event.page == nextion.pages.home }}'
+              - conditions: '{{ nspanel_event.page == pages.home }}'
                 sequence: *refresh_page_home
 
               ## PAGE BUTTON PAGES 01 - 04 ##
-              - conditions: '{{ nspanel_event.page in nextion.pages.buttonpages }}'
+              - conditions: '{{ nspanel_event.page in pages.buttonpages }}'
                 sequence: *refresh_page_buttonpage
 
               ## ENTITY PAGES ##
-              - conditions: '{{ nspanel_event.page in nextion.pages.entitypages }}'
+              - conditions: '{{ nspanel_event.page in pages.entitypages }}'
                 sequence: *refresh-entity_pages
 
       ##### UPDATE BUTTONS PAGES -  button page / lightsettings page / coversettings page  #####
@@ -7169,14 +7143,14 @@ action:
           - '{{ trigger.to_state.state not in ["unavailable", "unknown", "", None] }}'
           - condition: or
             conditions:
-              - '{{ nspanel_event.page in nextion.pages.buttonpages }}'
-              - '{{ nspanel_event.page in [nextion.pages.light, nextion.pages.cover, nextion.pages.climate] }}'
+              - '{{ nspanel_event.page in pages.buttonpages }}'
+              - '{{ nspanel_event.page in [pages.light, pages.cover, pages.climate] }}'
 
         sequence:
           - choose:
               - alias: "Button pages"
                 conditions:
-                  - '{{ nspanel_event.page in nextion.pages.buttonpages }}'
+                  - '{{ nspanel_event.page in pages.buttonpages }}'
                 sequence: #*refresh_page_buttonpage
                   - *variables-page_buttons
                   - repeat:
@@ -7192,17 +7166,17 @@ action:
                       sequence: *display-button_page_button
               - alias: 'Light settings page'
                 conditions:
-                  - '{{ nspanel_event.page == nextion.pages.light }}'
+                  - '{{ nspanel_event.page == pages.light }}'
                   - '{{ trigger.entity_id is match "light." }}'
                 sequence: *refresh_page_lightsettings
               - alias: 'Cover settings page'
                 conditions:
-                  - '{{ nspanel_event.page == nextion.pages.cover }}'
+                  - '{{ nspanel_event.page == pages.cover }}'
                   - '{{ trigger.entity_id is match "cover." }}'
                 sequence: *refresh_page_coversettings
               - alias: 'Climate page'
                 conditions:
-                  - '{{ nspanel_event.page == nextion.pages.climate }}'
+                  - '{{ nspanel_event.page == pages.climate }}'
                   - '{{ trigger.entity_id is match "climate." }}'
                 sequence: *refresh_page_climate
 
@@ -7216,7 +7190,7 @@ action:
               - home_value01_state
               - home_value02_state
               - home_value03_state
-          - '{{ nspanel_event.page == nextion.pages.home }}'
+          - '{{ nspanel_event.page == pages.home }}'
         sequence:
           - *variables-home_page_values
           - repeat:
@@ -7239,7 +7213,7 @@ action:
               - chip05_state
               - chip06_state
               - chip07_state
-          - '{{ nspanel_event.page == nextion.pages.home and trigger.event.data.new_state.state not in ["unavailable", "unknown", "", None] }}'
+          - '{{ nspanel_event.page == pages.home and trigger.event.data.new_state.state not in ["unavailable", "unknown", "", None] }}'
         sequence:
           - *variables-home_page_status_bar
           - repeat:
@@ -7260,7 +7234,7 @@ action:
             id:
               - notification_text_state
               - notification_unread_state
-          - '{{ nspanel_event.page == nextion.pages.home }}'
+          - '{{ nspanel_event.page == pages.home }}'
           - '{{ trigger.event.data.new_state.state not in ["unavailable", "unknown", "", None] }}'
         sequence:
           - alias: 'Set notifiy pic'
@@ -7368,7 +7342,7 @@ action:
             id:
               - left_button_state
               - right_button_state
-          - '{{ nspanel_event.page == nextion.pages.home }}'
+          - '{{ nspanel_event.page == pages.home }}'
           - '{{ trigger.to_state.state not in ["unavailable", "unknown", "", None] }}'
         sequence:
           ##### SET hardware Button PIC on Home Page ####
@@ -7389,7 +7363,7 @@ action:
         conditions:
           - condition: trigger
             id: time_state
-          - '{{ nspanel_event.page == nextion.pages.home }}'
+          - '{{ nspanel_event.page == pages.home }}'
         sequence:
           - *refresh-page_home-date_time
 
@@ -7398,7 +7372,7 @@ action:
         conditions:
           - condition: trigger
             id: outdoortemp_state
-          - '{{ nspanel_event.page == nextion.pages.home and is_number(trigger.event.data.new_state.state) }}'
+          - '{{ nspanel_event.page == pages.home and is_number(trigger.event.data.new_state.state) }}'
         sequence:
           - *refresh-page_home-outdoor_temp
 
@@ -7409,7 +7383,7 @@ action:
             id:
               - indoortemp_state
               - nspaneltemp_state
-          - '{{ nspanel_event.page == nextion.pages.home and is_number(trigger.event.data.new_state.state) }}'
+          - '{{ nspanel_event.page == pages.home and is_number(trigger.event.data.new_state.state) }}'
         sequence:
           - *refresh-page_home-indoor_temp
 
@@ -7418,7 +7392,7 @@ action:
         conditions:
           - condition: trigger
             id: weather_state_change
-          - '{{ nspanel_event.page == nextion.pages.home and trigger.event.data.new_state.state not in ["unavailable", "unknown", "", None] }}'
+          - '{{ nspanel_event.page == pages.home and trigger.event.data.new_state.state not in ["unavailable", "unknown", "", None] }}'
         sequence:
           - *refresh-page_home-outdoor_temp
           - *delay-default
@@ -7431,7 +7405,7 @@ action:
             id: climate_state
           - '{{ trigger.event.data.new_state.state not in ["unavailable", "unknown", "", None] }}'
           # - condition: template
-          #   value_template: '{{ nspanel_event.page == nextion.pages.climate }}'
+          #   value_template: '{{ nspanel_event.page == pages.climate }}'
           # - condition: template
           #   value_template: '{{ climate_optimistic == false }}'
         sequence:
@@ -7485,7 +7459,7 @@ action:
         conditions:
           - condition: trigger
             id: hotwatercharge_state
-          - '{{ nspanel_event.page == nextion.pages.climate }}'
+          - '{{ nspanel_event.page == pages.climate }}'
         sequence:
           - variables:
               hotw_bt_pic: '{{ nextion.pics.hvac.button[trigger.event.data.new_state.state] }}'
@@ -7499,7 +7473,7 @@ action:
         conditions:
           - condition: trigger
             id: hotwatertemp_state
-          - '{{ nspanel_event.page == nextion.pages.climate and trigger.event.data.new_state.state not in ["unavailable", "unknown", "", None] }}'
+          - '{{ nspanel_event.page == pages.climate and trigger.event.data.new_state.state not in ["unavailable", "unknown", "", None] }}'
         sequence:
           - service: '{{ nextion.commands.text_printf }}'
             data:
@@ -7535,14 +7509,14 @@ action:
         conditions:
           - condition: trigger
             id: sleep_mode_state
-          - "{{ nspanel_event.page == nextion.pages.screensaver }}"
+          - "{{ nspanel_event.page == pages.screensaver }}"
           - "{{ trigger.event.data.old_state.state == 'on' }}"
           - "{{ trigger.event.data.new_state.state == 'off' }}"
         sequence:
           - *delay-default
           - service: "{{ nextion.commands.printf }}"
             data:
-              cmd: "page {{ nextion.pages.home }}"
+              cmd: "page {{ pages.home }}"
             continue_on_error: true
 
 

--- a/nspanel_blueprint.yaml
+++ b/nspanel_blueprint.yaml
@@ -4428,6 +4428,167 @@ trigger:
       entity_id: !input 'entity32'
       id: current_state_entity32
 
+  ##### Trigger - Entity pages - State change ###############################################################################################
+    - alias: entities_entity01
+      platform: state
+      entity_id: !input 'entities_entity01'
+      id: trigger_entitypage01
+
+    - alias: entities_entity02
+      platform: state
+      entity_id: !input 'entities_entity02'
+      id: trigger_entitypage01
+
+    - alias: entities_entity03
+      platform: state
+      entity_id: !input 'entities_entity03'
+      id: trigger_entitypage01
+
+    - alias: entities_entity04
+      platform: state
+      entity_id: !input 'entities_entity04'
+      id: trigger_entitypage01
+
+    - alias: entities_entity05
+      platform: state
+      entity_id: !input 'entities_entity05'
+      id: trigger_entitypage01
+
+    - alias: entities_entity06
+      platform: state
+      entity_id: !input 'entities_entity06'
+      id: trigger_entitypage01
+
+    - alias: entities_entity07
+      platform: state
+      entity_id: !input 'entities_entity07'
+      id: trigger_entitypage01
+
+    - alias: entities_entity08
+      platform: state
+      entity_id: !input 'entities_entity08'
+      id: trigger_entitypage01
+
+    - alias: entities_entity09
+      platform: state
+      entity_id: !input 'entities_entity09'
+      id: trigger_entitypage02
+
+    - alias: entities_entity10
+      platform: state
+      entity_id: !input 'entities_entity10'
+      id: trigger_entitypage02
+
+    - alias: entities_entity11
+      platform: state
+      entity_id: !input 'entities_entity11'
+      id: trigger_entitypage02
+
+    - alias: entities_entity12
+      platform: state
+      entity_id: !input 'entities_entity12'
+      id: trigger_entitypage02
+
+    - alias: entities_entity13
+      platform: state
+      entity_id: !input 'entities_entity13'
+      id: trigger_entitypage02
+
+    - alias: entities_entity14
+      platform: state
+      entity_id: !input 'entities_entity14'
+      id: trigger_entitypage02
+
+    - alias: entities_entity15
+      platform: state
+      entity_id: !input 'entities_entity15'
+      id: trigger_entitypage02
+
+    - alias: entities_entity16
+      platform: state
+      entity_id: !input 'entities_entity16'
+      id: trigger_entitypage02
+
+    - alias: entities_entity17
+      platform: state
+      entity_id: !input 'entities_entity17'
+      id: trigger_entitypage03
+
+    - alias: entities_entity18
+      platform: state
+      entity_id: !input 'entities_entity18'
+      id: trigger_entitypage03
+
+    - alias: entities_entity19
+      platform: state
+      entity_id: !input 'entities_entity19'
+      id: trigger_entitypage03
+
+    - alias: entities_entity20
+      platform: state
+      entity_id: !input 'entities_entity20'
+      id: trigger_entitypage03
+
+    - alias: entities_entity21
+      platform: state
+      entity_id: !input 'entities_entity21'
+      id: trigger_entitypage03
+
+    - alias: entities_entity22
+      platform: state
+      entity_id: !input 'entities_entity22'
+      id: trigger_entitypage03
+
+    - alias: entities_entity23
+      platform: state
+      entity_id: !input 'entities_entity23'
+      id: trigger_entitypage03
+
+    - alias: entities_entity24
+      platform: state
+      entity_id: !input 'entities_entity24'
+      id: trigger_entitypage03
+
+    - alias: entities_entity25
+      platform: state
+      entity_id: !input 'entities_entity25'
+      id: trigger_entitypage04
+
+    - alias: entities_entity26
+      platform: state
+      entity_id: !input 'entities_entity26'
+      id: trigger_entitypage04
+
+    - alias: entities_entity27
+      platform: state
+      entity_id: !input 'entities_entity27'
+      id: trigger_entitypage04
+
+    - alias: entities_entity28
+      platform: state
+      entity_id: !input 'entities_entity28'
+      id: trigger_entitypage04
+
+    - alias: entities_entity29
+      platform: state
+      entity_id: !input 'entities_entity29'
+      id: trigger_entitypage04
+
+    - alias: entities_entity30
+      platform: state
+      entity_id: !input 'entities_entity30'
+      id: trigger_entitypage04
+
+    - alias: entities_entity31
+      platform: state
+      entity_id: !input 'entities_entity31'
+      id: trigger_entitypage04
+
+    - alias: entities_entity32
+      platform: state
+      entity_id: !input 'entities_entity32'
+      id: trigger_entitypage04
+
   ##### Trigger - Home - Chips - State change #################################################################################################################
     ##### Chip 01 - Trigger 'chip01_state' #####
     - platform: event
@@ -4746,6 +4907,34 @@ condition:
               - current_state_entity30
               - current_state_entity31
               - current_state_entity32
+      - alias: Entity page 01
+        condition: and
+        conditions:
+          - '{{ pages.entitypages[0] in states(nspanelevent) }}'
+          - condition: trigger
+            id:
+              - trigger_entitypage01
+      - alias: Entity page 02
+        condition: and
+        conditions:
+          - '{{ pages.entitypages[1] in states(nspanelevent) }}'
+          - condition: trigger
+            id:
+              - trigger_entitypage02
+      - alias: Entity page 03
+        condition: and
+        conditions:
+          - '{{ pages.entitypages[2] in states(nspanelevent) }}'
+          - condition: trigger
+            id:
+              - trigger_entitypage03
+      - alias: Entity page 04
+        condition: and
+        conditions:
+          - '{{ pages.entitypages[3] in states(nspanelevent) }}'
+          - condition: trigger
+            id:
+              - trigger_entitypage04
       - alias: Climate page
         condition: and
         conditions:
@@ -7179,6 +7368,30 @@ action:
                   - '{{ nspanel_event.page == pages.climate }}'
                   - '{{ trigger.entity_id is match "climate." }}'
                 sequence: *refresh_page_climate
+
+      ##### UPDATE ENTITY PAGES #####
+      - alias: 'Update entity pages'
+        conditions:
+          - condition: trigger
+            id:
+              - trigger_entitypage01
+              - trigger_entitypage02
+              - trigger_entitypage03
+              - trigger_entitypage04
+          - '{{ nspanel_event.page in pages.entitypages }}'
+        sequence:
+          - *variables-entity_pages
+          - repeat:
+              for_each: >
+                {{
+                  entity_pages_entities
+                  | selectattr("page", "defined")
+                  | selectattr("page", "eq", nspanel_event.page)
+                  | selectattr("entity", "defined")
+                  | selectattr("entity", "eq", trigger.entity_id)
+                  | list
+                }}
+              sequence: *update-entity_page_entity
 
       ########## TRIGGER - HOME PAGE ###########
 


### PR DESCRIPTION
- Adds condition to the automation to preventing it to run when an update to an entity which is not in the current page triggers the automation.
- Reduces the number of parallel instances and, with this, the number of entries in the logbook. (#304)
- Auto-update entity pages without compromising overall performance. (#410)