### PR TITLE
Wake up panel service call

### DIFF
--- a/nspanel_esphome.yaml
+++ b/nspanel_esphome.yaml
@@ -374,6 +374,8 @@ api:
             }
     ##### SERVICE TO WAKE UP THE DISPLAY #####
     - service: wake_up_display
+      variables:
+        option: string
       then:
         - if:
             condition:
@@ -383,14 +385,27 @@ api:
             then:
               - lambda: id(disp1).send_command_printf("page home");
             else:
-               - if:
+              - if:
                   condition:
                     text_sensor.state:
                       id: disp1_currentpage
                       state: 'home'
                   then:
                     - lambda: id(disp1).send_command_printf("dim=brightness.val");
-                    - lambda: id(disp1).send_command_printf("dimtimer.en=1"); 
+        - if:
+            condition:
+              - lambda: 'return option == "keep_wake";'
+            then:
+              - lambda: id(disp1).send_command_printf("home.dimtimer.en=1");
+              - lambda: id(disp1).send_command_printf("home.sleeptimer.en=1");
+        - if:
+            condition:
+              - lambda: 'return option == "keep_page";'
+            then:
+              - lambda: id(disp1).send_command_printf("home.dimtimer.en=1");
+              - lambda: id(disp1).send_command_printf("home.sleeptimer.en=1");
+              - lambda: |-
+                  id(page_timer)->execute(int(id(page_timeout).state));
 
     #### Service to set the entities ####
     - service: set_entity

--- a/nspanel_esphome.yaml
+++ b/nspanel_esphome.yaml
@@ -372,6 +372,25 @@ api:
             } else {
               id(disp1).set_component_text_printf(btnbri.c_str(), " ");
             }
+    ##### SERVICE TO WAKE UP THE DISPLAY #####
+    - service: wake_up_display
+      then:
+        - if:
+            condition:
+              text_sensor.state:
+                id: disp1_currentpage
+                state: 'screensaver'
+            then:
+              - lambda: id(disp1).send_command_printf("page home");
+            else:
+               - if:
+                  condition:
+                    text_sensor.state:
+                      id: disp1_currentpage
+                      state: 'home'
+                  then:
+                    - lambda: id(disp1).send_command_printf("dim=brightness.val");
+                    - lambda: id(disp1).send_command_printf("dimtimer.en=1"); 
 
     #### Service to set the entities ####
     - service: set_entity


### PR DESCRIPTION
I created an esphome service call, to wake up the display from dimmed or sleep state for whatever reason (motion sensor for example).
There is a string parameter for the service call, and there are three working modes:
- option value: anything (I'm not sure if there is an option for default string or empty string)
Wakes up the display, goes to the main page if sleeping, and set the brightness to the normal value if not sleeping
- option value: keep_wake
With this option, the service call also resets the dim and sleep timer option. So for example using this with a motion sensor, the display not only wakes up, but if the motion sensor keeps sending this service calls, it will prevent the display to go to sleep or dim the display
- option value: keep_page
With this option, you get the behavior as with the keep_wake option, but this option also resets the page timeout timer every time it's called. So as for the previous example, if I keep moving in front of the screen, the motion sensor will also prevent jumping back to the home screen.

I'm not sure if we need the first option at all (which does not reset the sleep and dim timers). One behavior which could be considered strange, if the service call occurs between 50 and 60 secs (50 sec is the dim timer timeout and 60 sec is the sleep timer timeout in the HMI file), the service call wakes up the display from dim mode (set back the brightness to the normal value), but after a couple of seconds the sleep timer will reach 60 secs and the display will go to sleep.