### PR TITLE
Top icon 1-3 as general chips

### DIFF
--- a/nspanel_blueprint.yaml
+++ b/nspanel_blueprint.yaml
@@ -5106,7 +5106,7 @@ action:
                                         repeat_item_state: '{{ states(repeat.item.entity) | default("unavailable") }}'
                                         repeat_item_state_is_on: >
                                           {{
-                                            (repeat_item_state is string and repeat_item_state in ["on", "open", "opening", "true", "True"]) or
+                                            (repeat_item_state is string and repeat_item_state in ["on", "open", "opening", "true", "True", "heat"]) or
                                             (repeat_item_state is boolean and repeat_item_state)
                                           }}
                                         repeat_item_icon: >

--- a/nspanel_blueprint.yaml
+++ b/nspanel_blueprint.yaml
@@ -558,9 +558,9 @@ blueprint:
             name: Chip 08 - ENTITY (Optional)
             description: >
               *HOME page*
-
+              
               *Entity which should be displayed (ONLY light | switch | binary_sensor | sensor | with state ON/OFF)*
-
+              
               *If left empty, the panel relay 2 entity is used instead*
             default: []
             selector: *chip-entity-selector
@@ -584,9 +584,9 @@ blueprint:
             name: Chip 09 - ENTITY (Optional)
             description: >
               *HOME page*
-
+              
               *Entity which should be displayed (ONLY light | switch | binary_sensor | sensor | with state ON/OFF)*
-
+              
               *If left empty, the panel relay 1 entity is used instead*
             default: []
             selector: *chip-entity-selector

--- a/nspanel_blueprint.yaml
+++ b/nspanel_blueprint.yaml
@@ -607,6 +607,33 @@ blueprint:
             default: [128, 128, 128] #33808 Grey light
             selector: *color-selector
 
+          chip10:
+            name: Chip 10 - ENTITY (Optional)
+            description: >
+              *HOME page*
+
+              *Entity which should be displayed (ONLY light | switch | binary_sensor | sensor | with state ON/OFF)*
+
+              *If left empty, chip will function as a thermostat chip*
+            default: []
+            selector: *chip-entity-selector
+          chip10_icon:
+            name: Chip 10 - ICON (Optional)
+            description: >
+              *HOME page*
+
+              *Icon which should be displayed when state ON (if not set, no icon is shown)*
+            default: []
+            selector: *icon-selector
+          chip10_icon_color:
+            name: Chip 10 - ICON COLOR (Optional)
+            description: >
+              *HOME page*
+
+              *Icon color which should be displayed*
+            default: [128, 128, 128] #33808 Grey light
+            selector: *color-selector
+
     ##### Climate - Page Climate #####
         ##### PLACEHOLDER ######################################################################
           placeholder04:
@@ -3377,6 +3404,8 @@ trigger_variables:
   display_target_temperature: 'sensor.{{ nspanel_name }}_display_target_temperature'
   chip08_entity: !input 'chip08'
   chip09_entity: !input 'chip09'
+  chip10_entity: !input 'chip10'
+  climate: !input 'climate'
   relay01_entity: 'switch.{{ nspanel_name }}_relay_1'
   relay02_entity: 'switch.{{ nspanel_name }}_relay_2'
   nspaneltemp: 'sensor.{{ nspanel_name }}_temperature'
@@ -4526,6 +4555,13 @@ trigger:
         entity_id: '{{ chip09_entity if chip09_entity | length > 0 else relay02_entity }}'
       id: chip09_state
 
+    ##### Chip 10 - Trigger 'chip10_state' #####
+    - platform: event
+      event_type: state_changed
+      event_data:
+        entity_id: '{{ chip10_entity if chip10_entity | length > 0 else climate }}'
+      id: chip10_state
+
   ##### Trigger - Home - Values - State change #################################################################################################################
 
     ##### HOME Value 01 - Trigger 'home_value01_state' #####
@@ -5062,7 +5098,10 @@ action:
                           ###### Status bar ######
                           - &variables-home_page_status_bar
                             variables:
+                              chip10_icon: !input 'chip10_icon'
+                              chip10_icon_color: !input 'chip10_icon_color'
                               thermostat_icon: !input 'thermostat_icon' #E50E
+                              thermostat_icon_color: !input 'thermostat_icon_color'
                               heat_icon: !input 'heat_icon' #\U0000E50F
                               climate_state: '{{ states(climate) | default("unavailable") if climate is string else "unavailable" }}'
                               climate_action: '{{ state_attr(climate, "hvac_action") | default("unavailable") if climate is string else "unavailable"  }}'
@@ -5112,18 +5151,28 @@ action:
                                   icon_color_rgb: !input 'chip09_icon_color'
                                   page: home
                                   component: icon_top_09
-                                - entity: '{{ climate }}'
+                                - entity: '{{ chip10_entity if chip10_entity | length > 0 else climate }}'
                                   icon: >
                                     {{
+                                      chip10_icon
+                                      if chip10_entity | length > 0
+                                      else
                                       (
-                                        all_icons[heat_icon.split(":")[1]] | default(heat_icon if heat_icon is string else all_icons.unknown)
-                                        if climate_action == "heating"
-                                        else all_icons[thermostat_icon.split(":")[1]] | default(thermostat_icon if thermostat_icon is string else all_icons.unknown)
+                                        (
+                                          all_icons[heat_icon.split(":")[1]] | default(heat_icon if heat_icon is string else all_icons.unknown)
+                                          if climate_action == "heating"
+                                          else all_icons[thermostat_icon.split(":")[1]] | default(thermostat_icon if thermostat_icon is string else all_icons.unknown)
+                                        )
+                                        if climate_state == "heat"
+                                        else all_icons.blank
                                       )
-                                      if climate_state == "heat"
-                                      else all_icons.blank
                                     }}
-                                  icon_color_rgb: !input 'thermostat_icon_color'
+                                  icon_color_rgb: >
+                                    {{
+                                      chip10_icon_color
+                                      if chip10_entity | length > 0
+                                      else thermostat_icon_color
+                                    }}
                                   page: home
                                   component: icon_top_10
                           - repeat:
@@ -7138,7 +7187,7 @@ action:
               - chip07_state
               - chip08_state
               - chip09_state
-              - climate_state
+              - chip10_state
           - '{{ nspanel_event.page == nextion.pages.home and trigger.event.data.new_state.state not in ["unavailable", "unknown", "", None] }}'
         sequence:
           - *variables-home_page_status_bar

--- a/nspanel_blueprint.yaml
+++ b/nspanel_blueprint.yaml
@@ -558,9 +558,9 @@ blueprint:
             name: Chip 08 - ENTITY (Optional)
             description: >
               *HOME page*
-              
+
               *Entity which should be displayed (ONLY light | switch | binary_sensor | sensor | with state ON/OFF)*
-              
+
               *If left empty, the panel relay 2 entity is used instead*
             default: []
             selector: *chip-entity-selector
@@ -584,9 +584,9 @@ blueprint:
             name: Chip 09 - ENTITY (Optional)
             description: >
               *HOME page*
-              
+
               *Entity which should be displayed (ONLY light | switch | binary_sensor | sensor | with state ON/OFF)*
-              
+
               *If left empty, the panel relay 1 entity is used instead*
             default: []
             selector: *chip-entity-selector
@@ -4511,14 +4511,14 @@ trigger:
       event_data:
         entity_id: !input 'chip07'
       id: chip07_state
-      
+
     ##### Chip 08 - Trigger 'chip08_state' #####
     - platform: event
       event_type: state_changed
       event_data:
         entity_id: '{{ chip08_entity if chip08_entity | length > 0 else relay01_entity }}'
       id: chip08_state
-      
+
     ##### Chip 09 - Trigger 'chip09_state' #####
     - platform: event
       event_type: state_changed

--- a/nspanel_blueprint.yaml
+++ b/nspanel_blueprint.yaml
@@ -558,9 +558,9 @@ blueprint:
             name: Chip 08 - ENTITY (Optional)
             description: >
               *HOME page*
-              
+
               *Entity which should be displayed (ONLY light | switch | binary_sensor | sensor | with state ON/OFF)*
-              
+
               *If left empty, the panel relay 2 entity is used instead*
             default: []
             selector: *chip-entity-selector
@@ -584,9 +584,9 @@ blueprint:
             name: Chip 09 - ENTITY (Optional)
             description: >
               *HOME page*
-              
+
               *Entity which should be displayed (ONLY light | switch | binary_sensor | sensor | with state ON/OFF)*
-              
+
               *If left empty, the panel relay 1 entity is used instead*
             default: []
             selector: *chip-entity-selector

--- a/nspanel_blueprint.yaml
+++ b/nspanel_blueprint.yaml
@@ -558,8 +558,10 @@ blueprint:
             name: Chip 08 - ENTITY (Optional)
             description: >
               *HOME page*
-              *Default is panel relay 1 if left empty*
+              
               *Entity which should be displayed (ONLY light | switch | binary_sensor | sensor | with state ON/OFF)*
+              
+              *If left empty, the panel relay 2 entity is used instead*
             default: []
             selector: *chip-entity-selector
           chip08_icon:
@@ -582,8 +584,10 @@ blueprint:
             name: Chip 09 - ENTITY (Optional)
             description: >
               *HOME page*
-              *Default is panel relay 2 if left empty*
+              
               *Entity which should be displayed (ONLY light | switch | binary_sensor | sensor | with state ON/OFF)*
+              
+              *If left empty, the panel relay 1 entity is used instead*
             default: []
             selector: *chip-entity-selector
           chip09_icon:

--- a/nspanel_blueprint.yaml
+++ b/nspanel_blueprint.yaml
@@ -5183,7 +5183,7 @@ action:
                                   then:
                                     - variables:
                                         repeat_item_state: '{{ states(repeat.item.entity) | default("unavailable") }}'
-                                        repeat_item_state_is_on: '{{ repeat_item_state in ["on", "open"] }}'
+                                        repeat_item_state_is_on: '{{ repeat_item_state in ["on", "open", "heat"] }}'
                                         repeat_item_icon: >
                                           {% if repeat_item_state_is_on and repeat.item.icon is string and repeat.item.icon | length > 0 %}
                                             {{ all_icons[repeat.item.icon.split(":")[1]] | default(repeat.item.icon) }}

--- a/nspanel_blueprint.yaml
+++ b/nspanel_blueprint.yaml
@@ -554,6 +554,54 @@ blueprint:
               *Icon color which should be displayed*
             default: [128, 128, 128] #33808 Grey light
             selector: *color-selector
+          chip08:
+            name: Chip 08 - ENTITY (Optional)
+            description: >
+              *HOME page*
+              *Default is panel relay 1 if left empty*
+              *Entity which should be displayed (ONLY light | switch | binary_sensor | sensor | with state ON/OFF)*
+            default: []
+            selector: *chip-entity-selector
+          chip08_icon:
+            name: Chip 08 - ICON (Optional)
+            description: >
+              *HOME page*
+
+              *Icon which should be displayed when state ON (if not set, no icon is shown)*
+            default: mdi:numeric-1-box-outline #   #E3A5
+            selector: *icon-selector
+          chip08_icon_color:
+            name: Chip 08 - ICON COLOR (Optional)
+            description: >
+              *HOME page*
+
+              *Icon color which should be displayed*
+            default: [128, 128, 128] #33808 Grey light
+            selector: *color-selector
+          chip09:
+            name: Chip 09 - ENTITY (Optional)
+            description: >
+              *HOME page*
+              *Default is panel relay 2 if left empty*
+              *Entity which should be displayed (ONLY light | switch | binary_sensor | sensor | with state ON/OFF)*
+            default: []
+            selector: *chip-entity-selector
+          chip09_icon:
+            name: Chip 09 - ICON (Optional)
+            description: >
+              *HOME page*
+
+              *Icon which should be displayed when state ON (if not set, no icon is shown)*
+            default: mdi:numeric-2-box-outline #   #E3A8
+            selector: *icon-selector
+          chip09_icon_color:
+            name: Chip 09 - ICON COLOR (Optional)
+            description: >
+              *HOME page*
+
+              *Icon color which should be displayed*
+            default: [128, 128, 128] #33808 Grey light
+            selector: *color-selector
 
     ##### Climate - Page Climate #####
         ##### PLACEHOLDER ######################################################################
@@ -3192,38 +3240,7 @@ blueprint:
               *Icon color which should be displayed (default color is set)*
             default: [248, 0, 0] #63488 Red
             selector: *color-selector
-          relay01_icon:
-            name: Relay 01 - ICON (Optional)
-            description: >
-              *HOME page*
 
-              *Icon which should be displayed (Default mdi:numeric-1-box-outline)*
-            default: mdi:numeric-1-box-outline #   #E3A5
-            selector: *icon-selector
-          relay01_icon_color:
-            name: Relay 01 - ICON COLOR (Optional)
-            description: >
-              *HOME page*
-
-              *Icon color which should be displayed (default color is set)*
-            default: [128, 128, 128] #33808 Grey light
-            selector: *color-selector
-          relay02_icon:
-            name: Relay 02 - ICON (Optional)
-            description: >
-              *HOME page*
-
-              *Icon which should be displayed (Default mdi:numeric-2-box-outline)*
-            default: mdi:numeric-2-box-outline #   #E3A8
-            selector: *icon-selector
-          relay02_icon_color:
-            name: Relay 02 - ICON COLOR (Optional)
-            description: >
-              *HOME page*
-
-              *Icon color which should be displayed (default color is set)*
-            default: [128, 128, 128] #33808 Grey light
-            selector: *color-selector
           thermostat_icon:
             name: Thermostat - ICON (Optional)
             description: >
@@ -3354,6 +3371,8 @@ trigger_variables:
   nspanelevent: 'sensor.{{ nspanel_name }}_nspanel_event'
   hotwatercharge: !input 'hotwatercharge'
   display_target_temperature: 'sensor.{{ nspanel_name }}_display_target_temperature'
+  chip08_entity: !input 'chip08'
+  chip09_entity: !input 'chip09'
   relay01_entity: 'switch.{{ nspanel_name }}_relay_1'
   relay02_entity: 'switch.{{ nspanel_name }}_relay_2'
   nspaneltemp: 'sensor.{{ nspanel_name }}_temperature'
@@ -4488,6 +4507,20 @@ trigger:
       event_data:
         entity_id: !input 'chip07'
       id: chip07_state
+      
+    ##### Chip 08 - Trigger 'chip08_state' #####
+    - platform: event
+      event_type: state_changed
+      event_data:
+        entity_id: '{{ chip08_entity if chip08_entity | length > 0 else relay01_entity }}'
+      id: chip08_state
+      
+    ##### Chip 09 - Trigger 'chip09_state' #####
+    - platform: event
+      event_type: state_changed
+      event_data:
+        entity_id: '{{ chip09_entity if chip09_entity | length > 0 else relay02_entity }}'
+      id: chip09_state
 
   ##### Trigger - Home - Values - State change #################################################################################################################
 
@@ -4514,22 +4547,6 @@ trigger:
         - unknown
         - unavailable
       id: home_value03_state
-
-  ##### Trigger - Relays - State change #################################################################################################################
-
-    ##### Relay01 - Trigger 'relay01_state' #####
-    - platform: event
-      event_type: state_changed
-      event_data:
-        entity_id: '{{ relay01_entity }}'
-      id: relay01_state
-
-    ##### Relay02 - Trigger 'relay02_state' #####
-    - platform: event
-      event_type: state_changed
-      event_data:
-        entity_id: '{{ relay02_entity }}'
-      id: relay02_state
 
   ##### Trigger - Climate - State change #################################################################################################################
     ##### Climate - Trigger 'climate_state' #####
@@ -5046,16 +5063,51 @@ action:
                               climate_state: '{{ states(climate) | default("unavailable") if climate is string else "unavailable" }}'
                               climate_action: '{{ state_attr(climate, "hvac_action") | default("unavailable") if climate is string else "unavailable"  }}'
                               home_page_status_bar:
-                                - entity: '{{ relay01_entity }}'
-                                  icon: !input 'relay01_icon' #E3A5
-                                  icon_color_rgb: !input 'relay01_icon_color'
+                                - entity: !input 'chip01'
+                                  icon: !input 'chip01_icon'
+                                  icon_color_rgb: !input 'chip01_icon_color'
                                   page: home
                                   component: icon_top_01
-                                - entity: '{{ relay02_entity }}'
-                                  icon: !input 'relay02_icon' #E3A8
-                                  icon_color_rgb: !input 'relay02_icon_color'
+                                - entity: !input 'chip02'
+                                  icon: !input 'chip02_icon'
+                                  icon_color_rgb: !input 'chip02_icon_color'
                                   page: home
                                   component: icon_top_02
+                                - entity: !input 'chip03'
+                                  icon: !input 'chip03_icon'
+                                  icon_color_rgb: !input 'chip03_icon_color'
+                                  page: home
+                                  component: icon_top_03
+                                - entity: !input 'chip04'
+                                  icon: !input 'chip04_icon'
+                                  icon_color_rgb: !input 'chip04_icon_color'
+                                  page: home
+                                  component: icon_top_04
+                                - entity: !input 'chip05'
+                                  icon: !input 'chip05_icon'
+                                  icon_color_rgb: !input 'chip05_icon_color'
+                                  page: home
+                                  component: icon_top_05
+                                - entity: !input 'chip06'
+                                  icon: !input 'chip06_icon'
+                                  icon_color_rgb: !input 'chip06_icon_color'
+                                  page: home
+                                  component: icon_top_06
+                                - entity: !input 'chip07'
+                                  icon: !input 'chip07_icon'
+                                  icon_color_rgb: !input 'chip07_icon_color'
+                                  page: home
+                                  component: icon_top_07
+                                - entity: '{{ chip08_entity if chip08_entity | length > 0 else relay01_entity }}'
+                                  icon: !input 'chip08_icon'
+                                  icon_color_rgb: !input 'chip08_icon_color'
+                                  page: home
+                                  component: icon_top_08
+                                - entity: '{{ chip09_entity if chip09_entity | length > 0 else relay02_entity }}'
+                                  icon: !input 'chip09_icon'
+                                  icon_color_rgb: !input 'chip09_icon_color'
+                                  page: home
+                                  component: icon_top_09
                                 - entity: '{{ climate }}'
                                   icon: >
                                     {{
@@ -5068,41 +5120,6 @@ action:
                                       else all_icons.blank
                                     }}
                                   icon_color_rgb: !input 'thermostat_icon_color'
-                                  page: home
-                                  component: icon_top_03
-                                - entity: !input 'chip01'
-                                  icon: !input 'chip01_icon'
-                                  icon_color_rgb: !input 'chip01_icon_color'
-                                  page: home
-                                  component: icon_top_04
-                                - entity: !input 'chip02'
-                                  icon: !input 'chip02_icon'
-                                  icon_color_rgb: !input 'chip02_icon_color'
-                                  page: home
-                                  component: icon_top_05
-                                - entity: !input 'chip03'
-                                  icon: !input 'chip03_icon'
-                                  icon_color_rgb: !input 'chip03_icon_color'
-                                  page: home
-                                  component: icon_top_06
-                                - entity: !input 'chip04'
-                                  icon: !input 'chip04_icon'
-                                  icon_color_rgb: !input 'chip04_icon_color'
-                                  page: home
-                                  component: icon_top_07
-                                - entity: !input 'chip05'
-                                  icon: !input 'chip05_icon'
-                                  icon_color_rgb: !input 'chip05_icon_color'
-                                  page: home
-                                  component: icon_top_08
-                                - entity: !input 'chip06'
-                                  icon: !input 'chip06_icon'
-                                  icon_color_rgb: !input 'chip06_icon_color'
-                                  page: home
-                                  component: icon_top_09
-                                - entity: !input 'chip07'
-                                  icon: !input 'chip07_icon'
-                                  icon_color_rgb: !input 'chip07_icon_color'
                                   page: home
                                   component: icon_top_10
                           - repeat:
@@ -7108,9 +7125,6 @@ action:
         conditions:
           - condition: trigger
             id:
-              - relay01_state
-              - relay02_state
-              - climate_state
               - chip01_state
               - chip02_state
               - chip03_state
@@ -7118,6 +7132,9 @@ action:
               - chip05_state
               - chip06_state
               - chip07_state
+              - chip08_state
+              - chip09_state
+              - climate_state
           - '{{ nspanel_event.page == nextion.pages.home and trigger.event.data.new_state.state not in ["unavailable", "unknown", "", None] }}'
         sequence:
           - *variables-home_page_status_bar


### PR DESCRIPTION
I started implementing what I suggested in #730.

- I created blueprint settings for chip8 and chip9
- If no entity is specified for chip8 and chip9 it uses relay1 and relay2 instead
- Thermostat chip is at the end now (top_icon_10)

There are two things that need to be done.
The first is what if somebody are using the panel's relays, not using chip8 and chip9, but does not want to display the relay status on the screen. Right now there are no way to assign nothing to chip 8/9. It's either the user supplied entity id or the relay's entity id.
Maybe we should ditch assigning the relay entities to a chip, and everybody can do it therself if they need it?

The second is the 10th chip, which is the thermostat chip. It's a little bit special with it's icon changing capabilities, but I think it can be done, that if the user assigns a not climate entity here it gets displayed like a normal chip.
But probably this functionality needs to get reworked a bit, to support other AC systems as well, not just heating.