### PR TITLE
Enable users select alignment for entity values

### DIFF
--- a/nspanel_blueprint.yaml
+++ b/nspanel_blueprint.yaml
@@ -2250,6 +2250,23 @@ blueprint:
               *Icon color which should be displayed (default color is set)*
             default: [200, 204, 200] #52857 Grey super light
             selector: *color-selector
+          entitypages_value_alignment:
+            name: Value column alignment
+            description: >
+              *Entity pages*
+
+              *Select the alignment for the column containing the values on the entity pages.*
+            default: "0"
+            selector:
+              select:
+                multiple: false
+                options:
+                  - label: "Right (default)"
+                    value: "0"
+                  - label: "Center"
+                    value: "1"
+                  - label: "Left"
+                    value: "2"
       ##### Entity page 01 - Entities #####
         ##### PLACEHOLDER ######################################################################
           placeholder12:
@@ -6120,6 +6137,16 @@ action:
                           - &variables-entity_pages
                             variables:
                               ##### Entity pages #####
+                              entitypages_value_alignment_temp: !input 'entitypages_value_alignment'
+                              entitypages_value_alignment: >
+                                {{
+                                  entitypages_value_alignment_temp | int
+                                  if
+                                    is_number(entitypages_value_alignment_temp) and
+                                    entitypages_value_alignment_temp | int >= 0 and
+                                    entitypages_value_alignment_temp | int <= 2
+                                  else 0
+                                }}
                               entity_pages_labels:
                                 - label: !input 'entity_page01_label'
                                 - label: !input 'entity_page02_label'
@@ -6317,6 +6344,14 @@ action:
                                           {% elif state_attr(repeat.item.entity, "icon") | default("") not in ["unavailable", "unknown", "", None] %}
                                             {{ all_icons[state_attr(repeat.item.entity, "icon").split(":")[1]] | default(None) }}
                                           {% endif %}
+                                    # DEBUG
+                                    - if: '{{ entitypages_value_alignment > 0 }}'
+                                      then:
+                                        - service: '{{ nextion.commands.printf }}'
+                                          data:
+                                            cmd: '{{ repeat.item.page }}.{{ repeat.item.component }}.xcen={{ entitypages_value_alignment }}'
+                                          continue_on_error: true
+                                        - *delay-default
                                     - service: '{{ nextion.commands.set_entity }}'
                                       data:
                                         ent_id: '{{ repeat.item.page }}.{{ repeat.item.component }}'


### PR DESCRIPTION
Users will be able to select the alignment for the column with values on the entity pages.
The options are:
- Right (default)
- Center
- Left

solves #732