### PR TITLE
Enable users select alignment for entity values

### DIFF
--- a/nspanel_blueprint.yaml
+++ b/nspanel_blueprint.yaml
@@ -2250,6 +2250,22 @@ blueprint:
               *Icon color which should be displayed (default color is set)*
             default: [200, 204, 200] #52857 Grey super light
             selector: *color-selector
+          entitypages_value_alignment:
+            name: Value column alignment
+            description: >
+              *Entity pages*
+              *Select the alignment for the column containing the values on the entity pages.*
+            default: "0"
+            selector:
+              select:
+                multiple: false
+                options:
+                  - label: "Right (default)"
+                    value: "0"
+                  - label: "Center"
+                    value: "1"
+                  - label: "Left"
+                    value: "2"
       ##### Entity page 01 - Entities #####
         ##### PLACEHOLDER ######################################################################
           placeholder12:
@@ -6134,6 +6150,16 @@ action:
                           - &variables-entity_pages
                             variables:
                               ##### Entity pages #####
+                              entitypages_value_alignment_temp: !input 'entitypages_value_alignment'
+                              entitypages_value_alignment: >
+                                {{
+                                  entitypages_value_alignment_temp | int
+                                  if
+                                    is_number(entitypages_value_alignment_temp) and
+                                    entitypages_value_alignment_temp | int >= 0 and
+                                    entitypages_value_alignment_temp | int <= 2
+                                  else 0
+                                }}
                               entity_pages_labels:
                                 - label: !input 'entity_page01_label'
                                 - label: !input 'entity_page02_label'
@@ -6341,6 +6367,7 @@ action:
                                           {%- else -%} {{ state_attr(repeat.item.entity, "friendly_name") | default(mui[language].no_name) }}
                                           {%- endif -%}
                                         ent_value: '{{ repeat_item_state ~ ((state_attr(repeat.item.entity, "unit_of_measurement") | default("")) if state_attr(repeat.item.entity, "unit_of_measurement") else "") }}'
+                                        ent_value_xcen: '{{ entitypages_value_alignment }}'
                                       continue_on_error: true
 
                       ## PAGE WEATHER (WEATHER01 to WEATHER05) ##

--- a/nspanel_esphome.yaml
+++ b/nspanel_esphome.yaml
@@ -410,6 +410,7 @@ api:
         ent_icon: string
         ent_label: string
         ent_value: string
+        ent_value_xcen: string
       then:
         - wait_until:
             binary_sensor.is_on: nextion_init
@@ -417,12 +418,16 @@ api:
             // ESP_LOGD("nextion", "set entity %s", ent_id.c_str());
             std::string enticon = ent_id.c_str() + std::string("_pic");
             std::string entlabel = ent_id.c_str() + std::string("_label");
+            std::string entxcen = ent_id.c_str() + std::string(".xcen=") + ent_value_xcen.c_str();
             id(disp1).set_component_text_printf(enticon.c_str(), "%s", ent_icon.c_str());
             if (strcmp(ent_icon.c_str(), "0") != 0) {
               id(disp1).set_component_text_printf(enticon.c_str(), "%s", ent_icon.c_str());
             }
             id(disp1).set_component_text_printf(entlabel.c_str(), "%s", ent_label.c_str());
             id(disp1).set_component_text_printf(ent_id.c_str(), "%s", ent_value.c_str());
+            if (strcmp(ent_value_xcen.c_str(), "0") != 0) {
+              id(disp1).send_command_printf("%s", entxcen.c_str());
+            }
 
 ##### START - GLOBALS CONFIGURATION #####
 globals:


### PR DESCRIPTION
Users will be able to select the alignment for the column with values on the entity pages. The options are:
- Right (default)
- Center
- Left

solves #732