### PR TITLE
Fix units on indoor temperature

### DIFF
--- a/nspanel_blueprint.yaml
+++ b/nspanel_blueprint.yaml
@@ -4978,17 +4978,7 @@ action:
                                   - service: '{{ nextion.commands.text_printf }}'
                                     data:
                                       component: home.current_temp
-                                      message: >
-                                        {{
-                                          (indoor_temp_state | round(1) ~ indoor_temp_units)
-                                          if is_number(indoor_temp_state)
-                                          else
-                                            (
-                                              mui[language].unavailable
-                                              if indoor_temp_state in ["unavailable", "unknown", "", None]
-                                              else indoor_temp_state
-                                            )
-                                        }}
+                                      message: '{{ indoor_temp_state | round(1) ~ indoor_temp_units }}'
                                     continue_on_error: true
 
                           ##### NSPanel Buttons #####

--- a/nspanel_blueprint.yaml
+++ b/nspanel_blueprint.yaml
@@ -4913,6 +4913,23 @@ action:
                               ##### NSPanel Indoor Temp #####
                               - variables:
                                   indoor_temp_state: '{{ states(indoortemp) | default("unavailable") if indoortemp is string and indoortemp is match "sensor." else states(nspaneltemp) }}'
+                                  indoor_temp_units: >
+                                    {{
+                                      state_attr(indoortemp, "unit_of_measurement") | default(temperature_units)
+                                      if
+                                        indoortemp is string and
+                                        indoortemp is match "sensor." and
+                                        state_attr(indoortemp, "unit_of_measurement") is string and
+                                        state_attr(indoortemp, "unit_of_measurement") | length > 0
+                                      else
+                                        (
+                                          state_attr(nspaneltemp, "unit_of_measurement") | default(temperature_units)
+                                          if
+                                            state_attr(nspaneltemp, "unit_of_measurement") is string and
+                                            state_attr(nspaneltemp, "unit_of_measurement") | length > 0
+                                          else temperature_units
+                                        )
+                                    }}
                               - if: '{{ is_number(indoor_temp_state) }}'
                                 then:
                                   ### ICON Indoor Temp Font Color ###
@@ -4961,7 +4978,17 @@ action:
                                   - service: '{{ nextion.commands.text_printf }}'
                                     data:
                                       component: home.current_temp
-                                      message: '{{ (indoor_temp_state | round(1) ~ temperature_units) if is_number(indoor_temp_state) else (mui[language].unavailable if indoor_temp_state in ["unavailable", "unknown", "", None] else indoor_temp_state) }}'
+                                      message: >
+                                        {{
+                                          (indoor_temp_state | round(1) ~ indoor_temp_units)
+                                          if is_number(indoor_temp_state)
+                                          else
+                                            (
+                                              mui[language].unavailable
+                                              if indoor_temp_state in ["unavailable", "unknown", "", None]
+                                              else indoor_temp_state
+                                            )
+                                        }}
                                     continue_on_error: true
 
                           ##### NSPanel Buttons #####


### PR DESCRIPTION
It will now show units from ùnit_of_measurement` to keep consistence with other value entities on Home page.

This solves #755