### PR TITLE
Fix crash climate without temperature attrb

### DIFF
--- a/nspanel_blueprint.yaml
+++ b/nspanel_blueprint.yaml
@@ -6375,13 +6375,13 @@ action:
                                 {% else %} Other
                                 {% endif %}
                               weather_units:
-                                hours_of_sun: '{{ state_attr(weather_entity, "hours_of_sun_unit") | default("h") if weather_entity is string and state_attr(weather_entity, "hours_of_sun_unit")               else "h" }}'
+                                hours_of_sun: '{{ state_attr(weather_entity, "hours_of_sun_unit") | default("h") if weather_entity is string and state_attr(weather_entity, "hours_of_sun_unit") else "h" }}'
                                 precipitation: '{{ state_attr(weather_entity, "precipitation_unit") | default("") if weather_entity is string and state_attr(weather_entity, "precipitation_unit") }}'
-                                precipitation_probability: '{{ state_attr(weather_entity, "precipitation_probability_unit") | default("%") if weather_entity is string and state_attr(weather_entity, "precipitation_probability_unit")  else "%" }}'
+                                precipitation_probability: '{{ state_attr(weather_entity, "precipitation_probability_unit") | default("%") if weather_entity is string and state_attr(weather_entity, "precipitation_probability_unit") else "%" }}'
                                 pressure: '{{ state_attr(weather_entity, "pressure_unit") | default("") if weather_entity is string and state_attr(weather_entity, "pressure_unit") }}'
-                                #temperature: '{{ state_attr(weather_entity, "temperature_unit") | default("°") if weather_entity is string and state_attr(weather_entity, "temperature_unit")                else "°" }}'
-                                thunderstorm_probability: '{{ state_attr(weather_entity, "thunderstorm_probability_unit") | default("%") if weather_entity is string and state_attr(weather_entity, "thunderstorm_probability_unit")   else "%" }}'
-                                uv_index: '{{ state_attr(weather_entity, "uv_index_unit") | default("") if weather_entity is string and state_attr(weather_entity, "uv_index_unit")   }}'
+                                #temperature: '{{ state_attr(weather_entity, "temperature_unit") | default("°") if weather_entity is string and state_attr(weather_entity, "temperature_unit") else "°" }}'
+                                thunderstorm_probability: '{{ state_attr(weather_entity, "thunderstorm_probability_unit") | default("%") if weather_entity is string and state_attr(weather_entity, "thunderstorm_probability_unit") else "%" }}'
+                                uv_index: '{{ state_attr(weather_entity, "uv_index_unit") | default("") if weather_entity is string and state_attr(weather_entity, "uv_index_unit") }}'
                                 #visibility: '{{ state_attr(weather_entity, "visibility_unit") | default("") if weather_entity is string and state_attr(weather_entity, "visibility_unit") }}'
                                 wind_speed: '{{ state_attr(weather_entity, "wind_speed_unit") | default("") if weather_entity is string and state_attr(weather_entity, "wind_speed_unit") }}'
                               page_name: '{{ nspanel_event.page }}'
@@ -7297,6 +7297,22 @@ action:
                   if trigger.event.data.new_state.state == "off"
                   else nextion.pics.heating.button.on
                 }}
+              target_temperature: >
+                    {{
+                      trigger.event.data.new_state.attributes.temperature | round(1)
+                      if
+                        trigger.event.data.new_state.attributes.temperature is defined and
+                        is_number(trigger.event.data.new_state.attributes.temperature)
+                      else
+                        (
+                          ((trigger.event.data.new_state.attributes.target_temp_high + trigger.event.data.new_state.attributes.target_temp_low) / 2) | round(1)
+                          if
+                            trigger.event.data.new_state.attributes.target_temp_high is defined and
+                            trigger.event.data.new_state.attributes.target_temp_low is defined and
+                            is_number(trigger.event.data.new_state.attributes.target_temp_high) and
+                            is_number(trigger.event.data.new_state.attributes.target_temp_low)
+                        )
+                    }}
 
           - service: '{{ nextion.commands.text_printf }}'
             data:
@@ -7312,11 +7328,11 @@ action:
             data:
               cmd: heating_bt_pic.pic={{ heating_bt_pic }}
             continue_on_error: true
-          - if: '{{ trigger.event.data.new_state.state != "off" }}' #### TODO AND->OR (not) not optimistic-mode
+          - if: '{{ trigger.event.data.new_state.state != "off" and is_number(target_temperature) }}' #### TODO AND->OR (not) not optimistic-mode
             then:
               - service: '{{ nextion.commands.thermostat_cycle }}'
                 data:
-                  value: '{{trigger.event.data.new_state.attributes.temperature | round(1)}}'
+                  value: ' {{ target_temperature }}'
                 continue_on_error: true
             else:
               - service: '{{ nextion.commands.thermostat_cycle }}'


### PR DESCRIPTION
The systems won't crash if the climate entity doesn't have a `temperature` attribute. It will try to calculate target from `target_temp_high` and `target_temp_low` otherwise will keep target temperature as empty.

This solves #749