### PR TITLE
Fix error when hw button is not `on`/`off`

### DIFF
--- a/nspanel_blueprint.yaml
+++ b/nspanel_blueprint.yaml
@@ -3465,7 +3465,13 @@ variables:
       hardware:
         button:
           "off": "77"
+          closed: "77"
+          closing: "77"
+          "false": "77"
           "on": "78"
+          open: "78"
+          opened: "78"
+          "true": "78"
       button:
         "off": "101"
         "on": "102"
@@ -5014,7 +5020,7 @@ action:
                             then:
                               - variables:
                                   # Hardware Button PIC
-                                  left_hardware_button_state: '{{ nextion.pics.hardware.button[left_button_state] | default(None) }}'
+                                  left_hardware_button_state: '{{ nextion.pics.hardware.button[left_button_state] | default(nextion.pics.hardware.button.off) }}'
                               - *delay-default
                               - service: '{{ nextion.commands.printf }}'
                                 data:
@@ -5049,7 +5055,7 @@ action:
                             then:
                               - variables:
                               # Hardware Button PIC
-                                  right_hardware_button_state: '{{ nextion.pics.hardware.button[right_button_state] | default(None) }}'
+                                  right_hardware_button_state: '{{ nextion.pics.hardware.button[right_button_state] | default(nextion.pics.hardware.button.off) }}'
                               - *delay-default
                               - service: '{{ nextion.commands.printf }}'
                                 data:


### PR DESCRIPTION
This prevents message `Nextion reported variable name invalid!` when the button have a state other than `on` or `off`, like when it is connected to a stateless entity (scene, automation, etc.).