### PR TITLE
Auto-update entities pages (simplified)

### DIFF
--- a/nspanel_blueprint.yaml
+++ b/nspanel_blueprint.yaml
@@ -4437,6 +4437,167 @@ trigger:
       entity_id: !input 'entity32'
       id: current_state_entity32
 
+  ##### Trigger - Entity pages - State change ###############################################################################################
+    - alias: entities_entity01
+      platform: state
+      entity_id: !input 'entities_entity01'
+      id: trigger_entitypage01
+
+    - alias: entities_entity02
+      platform: state
+      entity_id: !input 'entities_entity02'
+      id: trigger_entitypage01
+
+    - alias: entities_entity03
+      platform: state
+      entity_id: !input 'entities_entity03'
+      id: trigger_entitypage01
+
+    - alias: entities_entity04
+      platform: state
+      entity_id: !input 'entities_entity04'
+      id: trigger_entitypage01
+
+    - alias: entities_entity05
+      platform: state
+      entity_id: !input 'entities_entity05'
+      id: trigger_entitypage01
+
+    - alias: entities_entity06
+      platform: state
+      entity_id: !input 'entities_entity06'
+      id: trigger_entitypage01
+
+    - alias: entities_entity07
+      platform: state
+      entity_id: !input 'entities_entity07'
+      id: trigger_entitypage01
+
+    - alias: entities_entity08
+      platform: state
+      entity_id: !input 'entities_entity08'
+      id: trigger_entitypage01
+
+    - alias: entities_entity09
+      platform: state
+      entity_id: !input 'entities_entity09'
+      id: trigger_entitypage02
+
+    - alias: entities_entity10
+      platform: state
+      entity_id: !input 'entities_entity10'
+      id: trigger_entitypage02
+
+    - alias: entities_entity11
+      platform: state
+      entity_id: !input 'entities_entity11'
+      id: trigger_entitypage02
+
+    - alias: entities_entity12
+      platform: state
+      entity_id: !input 'entities_entity12'
+      id: trigger_entitypage02
+
+    - alias: entities_entity13
+      platform: state
+      entity_id: !input 'entities_entity13'
+      id: trigger_entitypage02
+
+    - alias: entities_entity14
+      platform: state
+      entity_id: !input 'entities_entity14'
+      id: trigger_entitypage02
+
+    - alias: entities_entity15
+      platform: state
+      entity_id: !input 'entities_entity15'
+      id: trigger_entitypage02
+
+    - alias: entities_entity16
+      platform: state
+      entity_id: !input 'entities_entity16'
+      id: trigger_entitypage02
+
+    - alias: entities_entity17
+      platform: state
+      entity_id: !input 'entities_entity17'
+      id: trigger_entitypage03
+
+    - alias: entities_entity18
+      platform: state
+      entity_id: !input 'entities_entity18'
+      id: trigger_entitypage03
+
+    - alias: entities_entity19
+      platform: state
+      entity_id: !input 'entities_entity19'
+      id: trigger_entitypage03
+
+    - alias: entities_entity20
+      platform: state
+      entity_id: !input 'entities_entity20'
+      id: trigger_entitypage03
+
+    - alias: entities_entity21
+      platform: state
+      entity_id: !input 'entities_entity21'
+      id: trigger_entitypage03
+
+    - alias: entities_entity22
+      platform: state
+      entity_id: !input 'entities_entity22'
+      id: trigger_entitypage03
+
+    - alias: entities_entity23
+      platform: state
+      entity_id: !input 'entities_entity23'
+      id: trigger_entitypage03
+
+    - alias: entities_entity24
+      platform: state
+      entity_id: !input 'entities_entity24'
+      id: trigger_entitypage03
+
+    - alias: entities_entity25
+      platform: state
+      entity_id: !input 'entities_entity25'
+      id: trigger_entitypage04
+
+    - alias: entities_entity26
+      platform: state
+      entity_id: !input 'entities_entity26'
+      id: trigger_entitypage04
+
+    - alias: entities_entity27
+      platform: state
+      entity_id: !input 'entities_entity27'
+      id: trigger_entitypage04
+
+    - alias: entities_entity28
+      platform: state
+      entity_id: !input 'entities_entity28'
+      id: trigger_entitypage04
+
+    - alias: entities_entity29
+      platform: state
+      entity_id: !input 'entities_entity29'
+      id: trigger_entitypage04
+
+    - alias: entities_entity30
+      platform: state
+      entity_id: !input 'entities_entity30'
+      id: trigger_entitypage04
+
+    - alias: entities_entity31
+      platform: state
+      entity_id: !input 'entities_entity31'
+      id: trigger_entitypage04
+
+    - alias: entities_entity32
+      platform: state
+      entity_id: !input 'entities_entity32'
+      id: trigger_entitypage04
+
   ##### Trigger - Home - Chips - State change #################################################################################################################
     ##### Chip 01 - Trigger 'chip01_state' #####
     - platform: event
@@ -4658,6 +4819,20 @@ trigger:
 
 condition:
   - '{{ is_state(nextion_inited, "on") | default(false) if nextion_inited is string else false }}'
+  - condition: or
+    conditions:
+      - condition: not
+        conditions:
+          - condition: trigger
+            id:
+              - trigger_entitypage01
+              - trigger_entitypage02
+              - trigger_entitypage03
+              - trigger_entitypage04
+      - '{{ pages.entitypages[0] in states(nspanelevent) }}'
+      - '{{ pages.entitypages[1] in states(nspanelevent) }}'
+      - '{{ pages.entitypages[2] in states(nspanelevent) }}'
+      - '{{ pages.entitypages[3] in states(nspanelevent) }}'
 
 #############################################################
 ##### START - Action #####
@@ -7107,6 +7282,30 @@ action:
                   - '{{ nspanel_event.page == pages.climate }}'
                   - '{{ trigger.entity_id is match "climate." }}'
                 sequence: *refresh_page_climate
+
+      ##### UPDATE ENTITY PAGES #####
+      - alias: 'Update entity pages'
+        conditions:
+          - condition: trigger
+            id:
+              - trigger_entitypage01
+              - trigger_entitypage02
+              - trigger_entitypage03
+              - trigger_entitypage04
+          - '{{ nspanel_event.page in pages.entitypages }}'
+        sequence:
+          - *variables-entity_pages
+          - repeat:
+              for_each: >
+                {{
+                  entity_pages_entities
+                  | selectattr("page", "defined")
+                  | selectattr("page", "eq", nspanel_event.page)
+                  | selectattr("entity", "defined")
+                  | selectattr("entity", "eq", trigger.entity_id)
+                  | list
+                }}
+              sequence: *update-entity_page_entity
 
       ########## TRIGGER - HOME PAGE ###########
 


### PR DESCRIPTION
This is a simplified version of #728 which is easier to maintain, as only conditions for entities pages have being added. So the scope is limited to:
- Auto-update entity pages without compromising overall performance. (Entities page values not updating unless re-opened #410)