### PR TITLE
Enable custom ota/web passwords

### DIFF
--- a/nspanel_esphome.yaml
+++ b/nspanel_esphome.yaml
@@ -5,18 +5,17 @@
 ##### For normal use with the Blueprint, no changes are necessary.                              #####
 #####################################################################################################
 
+substitutions:
+  ##### Defaults
+  baud_rate: "115200" # Requires 115200 if TFT is installed but can be changed to 9600 if TFT upload fails and nextion switches to 9600
+  ota_password: ${wifi_password} # As default the wifi password is used
+  web_password: ${wifi_password} # Per default the wifi password is used
 
 ##### ADVANCED CONFIGURATION - activate only when you know what you do ##############################
-substitutions:
-  baud_rate: "115200" # requires 115200 if tft is installed but can be changed to 9600 if tft upload fails and nextion switches to 9600
-  # ## usage of secrets-file ## -> comment in ###### Change ME ######
-  # device_name: "nspanel-name" # Wird im Blueprint benötigt!
-  # wifi_ssid: !secret nspanel_wifi_ssid # add in your esphome secrets file.
-  # wifi_password: !secret nspanel_wifi_password # add in your esphome secrets file. -> per default this is also used for ota_password and web_password
-  # ota_password: !secret nspanel_ota_password # add in your esphome secrets file. - manual change in code required to activate
-  # web_password: !secret nspanel_web_password # add in your esphome secrets file. - manual change in code required to activate
-  # api_password: !secret nspanel_api_password # add in your esphome secrets file. - manual change in code required to activate
-  # nextion_update_url: !secret nspanel_update_url # add in your esphome secrets file. Example: "http://"HOME ASSISTANT IP":8123/local/nspanel/nspanel.tft"
+  #device_name: "nspanel" # The network name of your panel
+  #wifi_ssid: !secret wifi_ssid # Add in your ESPHome secrets file.
+  #wifi_password: !secret wifi_password # Add in your ESPHome secrets file. -> per default this is also used for ota_password and web_password
+  # api_password: ${wifi_password} # Per default the wifi password is used
 
   # ## static ip config ##
   # ip: "10.0.0.7"
@@ -74,15 +73,11 @@ web_server:
   port: 80
   auth:
     username: admin
-    password: ${wifi_password}
-    ##### advanced config - change to use web_password #####
-    # password: ${web_password}
+    password: ${web_password}
 
 ##### OTA PASSWORD #####
 ota:
-  password: ${wifi_password}
-  ##### advanced config - change to use ota_password #####
-  # password: ${ota_password}
+  password: ${ota_password}
   safe_mode: true
   reboot_timeout: 3min
   num_attempts: 3
@@ -90,7 +85,6 @@ ota:
 ##### LOGGER #####
 logger:
   baud_rate: 0
-  # level: WARN
 
 ##### CONFIGURE INTERNAL BUZZER #####
 output:


### PR DESCRIPTION
Makes easier to customize ota & web passwords.
Allows users to set `ota_password` and `web_password` on the substitution on their ESPHome settings. This is not a breaking change as it uses the wifi password as default. API password not included as that would be a breaking change (currently no API password is used).