### PR TITLE
Fix `hvac_action` indication icons

### DIFF
--- a/nspanel_blueprint.yaml
+++ b/nspanel_blueprint.yaml
@@ -6543,15 +6543,14 @@ action:
                                   component: icon_top_02
                                 - entity: '{{ climate }}'
                                   icon: >
-                                    {{
-                                      (
-                                        all_icons[heat_icon.split(":")[1]] | default(heat_icon if heat_icon is string else all_icons.unknown)
-                                        if climate_action == "heating"
-                                        else all_icons[thermostat_icon.split(":")[1]] | default(thermostat_icon if thermostat_icon is string else all_icons.unknown)
-                                      )
-                                      if climate is string and is_state(climate, "heat")
-                                      else all_icons.blank
-                                    }}
+                                    {% if "off" in climate_action %}{{ all_icons.blank }}
+                                    {% elif "heating" in climate_action %}{{ all_icons.fire }}
+                                    {% elif "cooling" in climate_action %}{{ all_icons.snowflake }}
+                                    {% elif "drying" in climate_action %}{{ all_icons.water-percent }}
+                                    {% elif "fan" in climate_action %}{{ all_icons.fan }}
+                                    {% elif "idle" in climate_action %}{{ all_icons.blank }}
+                                    {% else %}{{ all_icons.blank }}
+                                    {% endif %}
                                   icon_color_rgb: !input 'thermostat_icon_color'
                                   page: home
                                   component: icon_top_03
@@ -7561,7 +7560,7 @@ action:
                                   for_each: '{{ climate_page_entities }}'
                                   sequence: *display_value
 
-                              ##### Slider #####
+                              ##### Slider & climate values #####
                               - &climate-update_slider
                                 if: '{{ true }}'
                                 then:
@@ -7583,6 +7582,16 @@ action:
                                         {% set target_temp_step = target_temp_step | float(0.5) | abs %}
                                         {{ ((10 * target_temp_step) | round(0) | int) if is_number(target_temp_step) and target_temp_step > 0 else 10 }}
                                       total_steps: '{{ ((max_temp-temp_offset)/temp_step) | round(0) | int }}'
+                                      hvac_action: '{{ state_attr(climate_entity, "hvac_action") }}'
+                                      climate_icon: >
+                                        {% if "off" in hvac_action %}{{ all_icons.blank }}
+                                        {% elif "heating" in hvac_action %}{{ all_icons.fire }}
+                                        {% elif "cooling" in hvac_action %}{{ all_icons.snowflake }}
+                                        {% elif "drying" in hvac_action %}{{ all_icons.water-percent }}
+                                        {% elif "fan" in hvac_action %}{{ all_icons.fan }}
+                                        {% elif "idle" in hvac_action %}{{ all_icons.blank }}
+                                        {% else %}{{ all_icons.blank }}
+                                        {% endif %}
                                   - *delay-default
                                   - service: '{{ nextion.command.set_climate }}'
                                     data:
@@ -7592,6 +7601,7 @@ action:
                                       total_steps: '{{ total_steps }}'
                                       slider_val: '{{ ((10*target_temp - temp_offset) / temp_step) | round(0) | int }}'
                                       temp_offset: '{{ temp_offset }}'
+                                      climate_icon: '{{ climate_icon }}'
                                     continue_on_error: true
 
                               ##### Climate buttons #####

--- a/nspanel_esphome.yaml
+++ b/nspanel_esphome.yaml
@@ -320,6 +320,7 @@ api:
         total_steps: int
         slider_val: int
         temp_offset: int
+        climate_icon: string
       then:
         - wait_until:
             binary_sensor.is_on: nextion_init
@@ -328,6 +329,7 @@ api:
               {
                 id(disp1).set_component_value("climateslider", slider_val);
                 id(disp1).set_component_text_printf("target_temp", "%.1f°", target_temp);
+                id(disp1).set_component_text_printf("target_icon", "%s", climate_icon.c_str());
                 id(disp1).show_component("target_icon");
                 id(disp1).show_component("target_temp");
                 id(disp1).show_component("climateslider");


### PR DESCRIPTION
Fix for pages home and climate.
This should remove the need for all the 25~30 instances of hot water in the code.