### PR TITLE
Remove inputs for chip3 (Climate)

### DIFF
--- a/nspanel_blueprint.yaml
+++ b/nspanel_blueprint.yaml
@@ -3442,30 +3442,6 @@ blueprint:
               *Icon color which should be displayed (default color is set)*
             default: [128, 128, 128] #33808 Grey light
             selector: *color-selector
-          thermostat_icon:
-            name: Thermostat - ICON (Optional)
-            description: >
-              *HOME page*
-
-              *Icon which should be displayed (Default mdi:thermometer)*
-            default: mdi:thermometer #   #E50E
-            selector: *icon-selector
-          heat_icon:
-            name: Thermostat - ICON (Optional)
-            description: >
-              *HOME page*
-
-              *Icon which should be displayed (Default mdi:thermometer-lines)*
-            default: mdi:thermometer-lines #   #E50F
-            selector: *icon-selector
-          thermostat_icon_color:
-            name: Thermostat / Heat - ICON COLOR (Optional)
-            description: >
-              *HOME page*
-
-              *Icon color which should be displayed (default color is set)*
-            default: [128, 128, 128] #33808 Grey light
-            selector: *color-selector
           time_label_color:
             name: Time - LABEL COLOR (Optional)
             description: >
@@ -6468,8 +6444,6 @@ action:
                           ###### Status bar ######
                           - &variables-home_page_status_bar
                             variables:
-                              thermostat_icon: !input 'thermostat_icon' #E50E
-                              heat_icon: !input 'heat_icon' #\uE50F
                               climate_state: '{{ states(climate) | default("unavailable") if climate is string else "unavailable" }}'
                               hvac_action: '{{ state_attr(climate, "hvac_action") | default("unavailable") if climate is string else "unavailable" }}'
                               climate_action: '{{ hvac_action if hvac_action not in ["unavailable", "unknown", "", None] else climate_state }}'
@@ -6496,7 +6470,17 @@ action:
                                     {% elif "idle" in climate_action %}{{ all_icons.thermometer }}
                                     {% else %}{{ all_icons.blank }}
                                     {% endif %}
-                                  icon_color_rgb: !input 'thermostat_icon_color'
+                                  icon_color_rgb: >
+                                    {% if "off" in climate_action %}{{ nextion.color["off"] }}
+                                    {% elif "heating" in climate_action or "heat" in climate_action %}{{ nextion.color["deep-orange"]}}
+                                    {% elif "cooling" in climate_action or "cool" in climate_action %}{{ nextion.color["blue"] }}
+                                    {% elif "drying" in climate_action or "dry" in climate_action %}{{ nextion.color["orange"] }}
+                                    {% elif "fan" in climate_action or "fan_only" in climate_action %}{{ nextion.color["cyan"] }}
+                                    {% elif "heat_cool" in climate_action %}{{ nextion.color["amber"] }}
+                                    {% elif "auto" in climate_action %}{{ nextion.color["green"] }}
+                                    {% elif "idle" in climate_action %}{{ nextion.color["off"] }}
+                                    {% else %}{{ nextion.color["off"] }}
+                                    {% endif %}
                                   page: home
                                   component: icon_top_03
                                 - entity: !input 'chip01'


### PR DESCRIPTION
Removed all inputs related to customization of chip03 (Climate entity) and instead will follow the same icons and colors used by page climate, with a thermometer replacing the fire icon for heating.