### PR TITLE
New language selector

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -25,12 +25,14 @@ Since in this update lots of input to the blueprint changed, we highly recommend
 &nbsp;
 ## Breaking changes
 1. New requirement: Home Assistant 2023.5.0 or later
+2. Exisiting users will have o select again the language for the panel, otherwise the automation will throw an error in the log related to the previous language selection.
 
 &nbsp;
 ## Overview of all changes
 1. Alarm control panel
 2. Support to sensor display precision from Home Assistant (#880)
-3. Filtered device list
+3. Filtered device list (#881)
+4. New language selector (#882)
 &nbsp;
 ## Details of all changes
 
@@ -51,7 +53,10 @@ Now the values shown in your panel will follow the [sensor display precision](ht
 When selecting the NSPanel on the automation, only ESP32 devices will be shown, making easier to find your panel.
 ![image](https://github.com/Blackymas/NSPanel_HA_Blueprint/assets/94725493/0e66bd6b-23c3-4014-8603-958acea48462)
 
-
+### 4. New language selector (#882)
+Starts using the new language selector release with HA 2023.5.0 and based on RFC 5646, which will increase reliability and standardization of the code.
+Althougt this is not visible for users at the first view, it will enable the use of more granualar language selections (like pt-BR vs pt-PT or en-US vs en-UK) if needed in the future.
+=> If you are an existing users, please remember to select your language again after the update, as the previous selection will be invalid.
 &nbsp;
 
 ## Next topics we are currently working on

--- a/nspanel_blueprint.yaml
+++ b/nspanel_blueprint.yaml
@@ -18,19 +18,19 @@ blueprint:
     The goal was to create a version that allows everyone to use the NSpanel fully local without having to deal with programming or reading hours of documentation - *AND YES WE DID IT!!!!* ;)
 
 
-    📕 Full documentation and installation video is available here [NSPanel Configuration, Setup and HowTo](https://github.com/Blackymas/NSPanel_HA_Blueprint/wiki).
+    📕 Full documentation and installation video is available here: [NSPanel Configuration, Setup and HowTo](https://github.com/Blackymas/NSPanel_HA_Blueprint/wiki).
 
 
     📌 Step by Step - [Setup Video](https://www.youtube.com/watch?v=3afPFg6kUdc)
 
 
-    🚀 How to create "Issues" when I have a problem [WIKI HowTo](https://github.com/Blackymas/NSPanel_HA_Blueprint/wiki)
+    🚀 How to create "Issues" when I have a problem: [WIKI HowTo](https://github.com/Blackymas/NSPanel_HA_Blueprint/wiki)
 
 
-    ⭐ All Feature Requests can be found here [All Feature Request](https://github.com/Blackymas/NSPanel_HA_Blueprint/labels/new%20feature%20request)
+    ⭐ All Feature Requests can be found here: [All Feature Request](https://github.com/Blackymas/NSPanel_HA_Blueprint/labels/new%20feature%20request)
 
 
-    🎉 Roadmap Roadmap can be found here [Roadmap](https://github.com/Blackymas/NSPanel_HA_Blueprint/labels/roadmap)
+    🎉 Roadmap can be found here: [Roadmap](https://github.com/Blackymas/NSPanel_HA_Blueprint/labels/roadmap)
 
 
     ℹ️ Version: v.3.5_dev
@@ -64,67 +64,10 @@ blueprint:
               *SYSTEM settings*
 
               *Select the language for your NSPanel*
-            default: 'ENG'
+            default: en
             selector:
-              select:
-                mode: dropdown
-                options:
-                  - label: 'Bulgarian'
-                    value: BGR
-                  - label: 'Croatian'
-                    value: HRV
-                  - label: 'Czech'
-                    value: CZE
-                  - label: 'Danish'
-                    value: DNK
-                  - label: 'Dutch'
-                    value: NLD
-                  - label: 'English'
-                    value: ENG
-                  - label: 'Estonian'
-                    value: EST
-                  - label: 'Finnish'
-                    value: FIN
-                  - label: 'French'
-                    value: FRA
-                  - label: 'German'
-                    value: DEU
-                  - label: 'Greek'
-                    value: GRC
-                  - label: 'Hebrew'
-                    value: HEB
-                  - label: 'Hungarian'
-                    value: HUN
-                  - label: 'Indonesian'
-                    value: IDN
-                  - label: 'Italian'
-                    value: ITA
-                  - label: 'Latvian'
-                    value: LVA
-                  - label: 'Lithuanian'
-                    value: LTU
-                  - label: 'Norwegian'
-                    value: NOR
-                  - label: 'Polish'
-                    value: POL
-                  - label: 'Portuguese'
-                    value: PRT
-                  - label: 'Romanian'
-                    value: ROU
-                  - label: 'Russian'
-                    value: RUS
-                  - label: 'Slovak'
-                    value: SVK
-                  - label: 'Slovene'
-                    value: SVN
-                  - label: 'Spanish'
-                    value: ESP
-                  - label: 'Swedish'
-                    value: SWE
-                  - label: 'Turkish'
-                    value: TUR
-                  - label: 'Ukrainian'
-                    value: UKR
+              language:
+                languages: [en, bg, hr, cs, da, nl, et, fi, fr, de, el, he, hu, id, it, lv, lt, nb, pl, pt, ro, ru, sk, sl, es, sv, tr, uk]
           date_format:
             name: Date Format
             description: >
@@ -3689,7 +3632,7 @@ variables:
 
   ##### MUI Multilingual User Interface #####
   mui:
-    BGR:
+    bg: #Bulgarian
       weekdays:
         mon: Понеделник
         tue: Вторник
@@ -3746,7 +3689,7 @@ variables:
       please_confirm: Моля, потвърдете
       unavailable: Недостъпен
       no_name: Няма име
-    CZE:
+    cs: #Czech
       weekdays:
         mon: Pondělí
         tue: Úterý
@@ -3803,64 +3746,7 @@ variables:
       please_confirm: Potvrďte prosím
       unavailable: Unavailable
       no_name: No name
-    DEU: #German
-      weekdays:
-        mon: Montag
-        tue: Dienstag
-        wed: Mittwoch
-        thu: Donnerstag
-        fri: Freitag
-        sat: Samstag
-        sun: Sonntag
-      weekdays_short:
-        mon: Mo.
-        tue: Di.
-        wed: Mi.
-        thu: Do.
-        fri: Fr.
-        sat: Sa.
-        sun: So.
-      months:
-        jan: Januar
-        feb: Februar
-        mar: März
-        apr: April
-        may: Mai
-        jun: Juni
-        jul: Juli
-        aug: August
-        sep: September
-        oct: Oktober
-        nov: November
-        dec: Dezember
-      months_short:
-        jan: Jan.
-        feb: Feb.
-        mar: März
-        apr: Apr.
-        may: Mai
-        jun: Jun.
-        jul: Jul.
-        aug: Aug.
-        sep: Sept.
-        oct: Okt.
-        nov: Nov.
-        dec: Dez.
-      relative_day:
-        today: Heute
-        tomorrow: Morgen
-        in_2_days: in 2 Tagen
-        in_3_days: in 3 Tagen
-        in_4_days: in 4 Tagen
-      climate:
-        states:
-          "on": ein
-          "off": aus
-        heat: heizen
-      please_confirm: Bitte bestätigen
-      unavailable: Unavailable
-      no_name: No name
-    DNK:
+    da: #Danish
       weekdays:
         mon: Mandag
         tue: Tirsdag
@@ -3917,292 +3803,64 @@ variables:
       please_confirm: Bekræft venligst
       unavailable: Unavailable
       no_name: No name
-    ENG: #English
+    de: #German
       weekdays:
-        mon: Monday
-        tue: Tuesday
-        wed: Wednesday
-        thu: Thursday
-        fri: Friday
-        sat: Saturday
-        sun: Sunday
+        mon: Montag
+        tue: Dienstag
+        wed: Mittwoch
+        thu: Donnerstag
+        fri: Freitag
+        sat: Samstag
+        sun: Sonntag
       weekdays_short:
-        mon: Mon
-        tue: Tue
-        wed: Wed
-        thu: Thu
-        fri: Fri
-        sat: Sat
-        sun: Sun
+        mon: Mo.
+        tue: Di.
+        wed: Mi.
+        thu: Do.
+        fri: Fr.
+        sat: Sa.
+        sun: So.
       months:
-        jan: January
-        feb: February
-        mar: March
+        jan: Januar
+        feb: Februar
+        mar: März
         apr: April
-        may: May
-        jun: June
-        jul: July
+        may: Mai
+        jun: Juni
+        jul: Juli
         aug: August
         sep: September
-        oct: October
+        oct: Oktober
         nov: November
-        dec: December
+        dec: Dezember
       months_short:
-        jan: Jan
-        feb: Feb
-        mar: Mar
-        apr: Apr
-        may: May
-        jun: Jun
-        jul: Jul
-        aug: Aug
-        sep: Sep
-        oct: Oct
-        nov: Nov
-        dec: Dec
-      relative_day:
-        today: Today
-        tomorrow: Tomorrow
-        in_2_days: In 2 days
-        in_3_days: In 3 days
-        in_4_days: In 4 days
-      climate:
-        states:
-          "on": on
-          "off": off
-        heat: heat
-      please_confirm: Please confirm
-      unavailable: Unavailable
-      no_name: No name
-    ESP: #Spanish
-      weekdays:
-        mon: Lunes
-        tue: Martes
-        wed: Miércoles
-        thu: Jueves
-        fri: Viernes
-        sat: Sábado
-        sun: Domingo
-      weekdays_short:
-        mon: Lun
-        tue: Mar
-        wed: Mie
-        thu: Jue
-        fri: Vie
-        sat: Sab
-        sun: Dom
-      months:
-        jan: Enero
-        feb: Febrero
-        mar: Marzo
-        apr: Abril
-        may: Mayo
-        jun: Junio
-        jul: Julio
-        aug: Agosto
-        sep: Septiembre
-        oct: Octubre
-        nov: Noviembre
-        dec: Diciembre
-      months_short:
-        jan: Ene
-        feb: Feb
-        mar: Mar
-        apr: Abr
-        may: May
-        jun: Jun
-        jul: Jul
-        aug: Ago
-        sep: Sep
-        oct: Oct
-        nov: Nov
-        dec: Dic
-      relative_day:
-        today: Hoy
-        tomorrow: Mañana
-        in_2_days: En 2 días
-        in_3_days: En 3 días
-        in_4_days: En 4 días
-      climate:
-        states:
-          "on": Encendido
-          "off": Apagado
-        heat: calor
-      please_confirm: Por favor, confirme
-      unavailable: No disponible
-      no_name: Sin nombre
-    EST:
-      weekdays:
-        mon: Esmaspäev
-        tue: Teisipäev
-        wed: Kolmapäev
-        thu: Neljapäev
-        fri: Reede
-        sat: Laupäev
-        sun: Pühapäev
-      weekdays_short:
-        mon: Mon
-        tue: Tue
-        wed: Wed
-        thu: Thu
-        fri: Fri
-        sat: Sat
-        sun: Sun
-      months:
-        jan: January
-        feb: February
-        mar: March
-        apr: April
-        may: May
-        jun: June
-        jul: July
-        aug: August
-        sep: September
-        oct: October
-        nov: November
-        dec: December
-      months_short:
-        jan: Jan
-        feb: Feb
-        mar: Mar
-        apr: Apr
-        may: May
-        jun: Jun
-        jul: Jul
-        aug: Aug
-        sep: Sep
-        oct: Oct
-        nov: Nov
-        dec: Dec
-      relative_day:
-        today: Täna
-        tomorrow: Homme
-        in_2_days: 2 päeva pärast
-        in_3_days: 3 päeva pärast
-        in_4_days: 4 päeva pärast
-      climate:
-        states:
-          "on": aadressil
-          "off": välja
-        heat: soojus
-      please_confirm: Palun kinnitage
-      unavailable: Unavailable
-      no_name: No name
-    FIN: #Finnish
-      weekdays:
-        mon: Maanantai
-        tue: Tiistai
-        wed: Keskiviikko
-        thu: Torstai
-        fri: Perjantai
-        sat: Lauantai
-        sun: Sunnuntai
-      weekdays_short:
-        mon: Ma
-        tue: Ti
-        wed: Ke
-        thu: To
-        fri: Pe
-        sat: La
-        sun: Su
-      months:
-        jan: Tammikuu
-        feb: Helmikuu
-        mar: Maaliskuu
-        apr: Huhtikuu
-        may: Toukokuu
-        jun: Kesäkuu
-        jul: Heinäkuu
-        aug: Elokuu
-        sep: Syyskuu
-        oct: Lokakuu
-        nov: Marraskuu
-        dec: Joulukuu
-      months_short:
-        jan: Tammi
-        feb: Helmi
-        mar: Maalis
-        apr: Huhti
-        may: Touko
-        jun: Kesä
-        jul: Heinä
-        aug: Elo
-        sep: Syys
-        oct: Loka
-        nov: Marras
-        dec: Joulu
-      relative_day:
-        today: Tänään
-        tomorrow: Huomenna
-        in_2_days: 2 päivän päästä
-        in_3_days: 3 päivän päästä
-        in_4_days: 4 päivän päästä
-      climate:
-        states:
-          "on": "On"
-          "off": "Off"
-        heat: lämpö
-      please_confirm: Vahvista
-      unavailable: Unavailable
-      no_name: No name
-    FRA: #French
-      weekdays:
-        mon: Lundi
-        tue: Mardi
-        wed: Mercredi
-        thu: Jeudi
-        fri: Vendredi
-        sat: Samedi
-        sun: Dimanche
-      weekdays_short:
-        mon: Lun
-        tue: Mar
-        wed: Mer
-        thu: Jeu
-        fri: Ven
-        sat: Sam
-        sun: Dim
-      months:
-        jan: Janvier
-        feb: Février
-        mar: Mars
-        apr: Avril
+        jan: Jan.
+        feb: Feb.
+        mar: März
+        apr: Apr.
         may: Mai
-        jun: Juin
-        jul: Juillet
-        aug: Août
-        sep: Septembre
-        oct: Octobre
-        nov: Novembre
-        dec: Decembre
-      months_short:
-        jan: Jan
-        feb: Feb
-        mar: Mar
-        apr: Apr
-        may: Mai
-        jun: Jun
-        jul: Jul
-        aug: Aoû
-        sep: Sep
-        oct: Oct
-        nov: Nov
-        dec: Dec
+        jun: Jun.
+        jul: Jul.
+        aug: Aug.
+        sep: Sept.
+        oct: Okt.
+        nov: Nov.
+        dec: Dez.
       relative_day:
-        today: Aujourd hui
-        tomorrow: Demain
-        in_2_days: Dans 2 jours
-        in_3_days: Dans 3 jours
-        in_4_days: Dans 4 jours
+        today: Heute
+        tomorrow: Morgen
+        in_2_days: in 2 Tagen
+        in_3_days: in 3 Tagen
+        in_4_days: in 4 Tagen
       climate:
         states:
-          "on": on
-          "off": off
-        heat: Chaleur
-      please_confirm: Veuillez confirmer
-      unavailable: Indisponible
-      no_name: Sans nom
-    GRC: #Greek
+          "on": ein
+          "off": aus
+        heat: heizen
+      please_confirm: Bitte bestätigen
+      unavailable: Unavailable
+      no_name: No name
+    el: #Greek
       weekdays:
         mon: Δευτέρα
         tue: Τρίτη
@@ -4259,7 +3917,292 @@ variables:
       please_confirm: Παρακαλώ επιβεβαιώστε
       unavailable: Μη διαθέσιμο
       no_name: Χωρίς όνομα
-    HEB: #Hebrew
+    en: #English
+      weekdays:
+        mon: Monday
+        tue: Tuesday
+        wed: Wednesday
+        thu: Thursday
+        fri: Friday
+        sat: Saturday
+        sun: Sunday
+      weekdays_short:
+        mon: Mon
+        tue: Tue
+        wed: Wed
+        thu: Thu
+        fri: Fri
+        sat: Sat
+        sun: Sun
+      months:
+        jan: January
+        feb: February
+        mar: March
+        apr: April
+        may: May
+        jun: June
+        jul: July
+        aug: August
+        sep: September
+        oct: October
+        nov: November
+        dec: December
+      months_short:
+        jan: Jan
+        feb: Feb
+        mar: Mar
+        apr: Apr
+        may: May
+        jun: Jun
+        jul: Jul
+        aug: Aug
+        sep: Sep
+        oct: Oct
+        nov: Nov
+        dec: Dec
+      relative_day:
+        today: Today
+        tomorrow: Tomorrow
+        in_2_days: In 2 days
+        in_3_days: In 3 days
+        in_4_days: In 4 days
+      climate:
+        states:
+          "on": on
+          "off": off
+        heat: heat
+      please_confirm: Please confirm
+      unavailable: Unavailable
+      no_name: No name
+    es: #Spanish
+      weekdays:
+        mon: Lunes
+        tue: Martes
+        wed: Miércoles
+        thu: Jueves
+        fri: Viernes
+        sat: Sábado
+        sun: Domingo
+      weekdays_short:
+        mon: Lun
+        tue: Mar
+        wed: Mie
+        thu: Jue
+        fri: Vie
+        sat: Sab
+        sun: Dom
+      months:
+        jan: Enero
+        feb: Febrero
+        mar: Marzo
+        apr: Abril
+        may: Mayo
+        jun: Junio
+        jul: Julio
+        aug: Agosto
+        sep: Septiembre
+        oct: Octubre
+        nov: Noviembre
+        dec: Diciembre
+      months_short:
+        jan: Ene
+        feb: Feb
+        mar: Mar
+        apr: Abr
+        may: May
+        jun: Jun
+        jul: Jul
+        aug: Ago
+        sep: Sep
+        oct: Oct
+        nov: Nov
+        dec: Dic
+      relative_day:
+        today: Hoy
+        tomorrow: Mañana
+        in_2_days: En 2 días
+        in_3_days: En 3 días
+        in_4_days: En 4 días
+      climate:
+        states:
+          "on": Encendido
+          "off": Apagado
+        heat: calor
+      please_confirm: Por favor, confirme
+      unavailable: No disponible
+      no_name: Sin nombre
+    et: #Estonian
+      weekdays:
+        mon: Esmaspäev
+        tue: Teisipäev
+        wed: Kolmapäev
+        thu: Neljapäev
+        fri: Reede
+        sat: Laupäev
+        sun: Pühapäev
+      weekdays_short:
+        mon: Mon
+        tue: Tue
+        wed: Wed
+        thu: Thu
+        fri: Fri
+        sat: Sat
+        sun: Sun
+      months:
+        jan: January
+        feb: February
+        mar: March
+        apr: April
+        may: May
+        jun: June
+        jul: July
+        aug: August
+        sep: September
+        oct: October
+        nov: November
+        dec: December
+      months_short:
+        jan: Jan
+        feb: Feb
+        mar: Mar
+        apr: Apr
+        may: May
+        jun: Jun
+        jul: Jul
+        aug: Aug
+        sep: Sep
+        oct: Oct
+        nov: Nov
+        dec: Dec
+      relative_day:
+        today: Täna
+        tomorrow: Homme
+        in_2_days: 2 päeva pärast
+        in_3_days: 3 päeva pärast
+        in_4_days: 4 päeva pärast
+      climate:
+        states:
+          "on": aadressil
+          "off": välja
+        heat: soojus
+      please_confirm: Palun kinnitage
+      unavailable: Unavailable
+      no_name: No name
+    fi: #Finnish
+      weekdays:
+        mon: Maanantai
+        tue: Tiistai
+        wed: Keskiviikko
+        thu: Torstai
+        fri: Perjantai
+        sat: Lauantai
+        sun: Sunnuntai
+      weekdays_short:
+        mon: Ma
+        tue: Ti
+        wed: Ke
+        thu: To
+        fri: Pe
+        sat: La
+        sun: Su
+      months:
+        jan: Tammikuu
+        feb: Helmikuu
+        mar: Maaliskuu
+        apr: Huhtikuu
+        may: Toukokuu
+        jun: Kesäkuu
+        jul: Heinäkuu
+        aug: Elokuu
+        sep: Syyskuu
+        oct: Lokakuu
+        nov: Marraskuu
+        dec: Joulukuu
+      months_short:
+        jan: Tammi
+        feb: Helmi
+        mar: Maalis
+        apr: Huhti
+        may: Touko
+        jun: Kesä
+        jul: Heinä
+        aug: Elo
+        sep: Syys
+        oct: Loka
+        nov: Marras
+        dec: Joulu
+      relative_day:
+        today: Tänään
+        tomorrow: Huomenna
+        in_2_days: 2 päivän päästä
+        in_3_days: 3 päivän päästä
+        in_4_days: 4 päivän päästä
+      climate:
+        states:
+          "on": "On"
+          "off": "Off"
+        heat: lämpö
+      please_confirm: Vahvista
+      unavailable: Unavailable
+      no_name: No name
+    fr: #French
+      weekdays:
+        mon: Lundi
+        tue: Mardi
+        wed: Mercredi
+        thu: Jeudi
+        fri: Vendredi
+        sat: Samedi
+        sun: Dimanche
+      weekdays_short:
+        mon: Lun
+        tue: Mar
+        wed: Mer
+        thu: Jeu
+        fri: Ven
+        sat: Sam
+        sun: Dim
+      months:
+        jan: Janvier
+        feb: Février
+        mar: Mars
+        apr: Avril
+        may: Mai
+        jun: Juin
+        jul: Juillet
+        aug: Août
+        sep: Septembre
+        oct: Octobre
+        nov: Novembre
+        dec: Decembre
+      months_short:
+        jan: Jan
+        feb: Feb
+        mar: Mar
+        apr: Apr
+        may: Mai
+        jun: Jun
+        jul: Jul
+        aug: Aoû
+        sep: Sep
+        oct: Oct
+        nov: Nov
+        dec: Dec
+      relative_day:
+        today: Aujourd hui
+        tomorrow: Demain
+        in_2_days: Dans 2 jours
+        in_3_days: Dans 3 jours
+        in_4_days: Dans 4 jours
+      climate:
+        states:
+          "on": on
+          "off": off
+        heat: Chaleur
+      please_confirm: Veuillez confirmer
+      unavailable: Indisponible
+      no_name: Sans nom
+    he: #Hebrew
       weekdays:
         mon: ינש
         tue: ישילש
@@ -4316,7 +4259,7 @@ variables:
       please_confirm: רשא השקבב
       unavailable: Unavailable
       no_name: No name
-    HRV: #Croatian
+    hr: #Croatian
       weekdays:
         mon: Ponedjeljak
         tue: Utorak
@@ -4373,7 +4316,7 @@ variables:
       please_confirm: Molim potvrdite
       unavailable: Nedostupno
       no_name: Bez imena
-    HUN:
+    hu: #Hungarian
       weekdays:
         mon: Hétfő
         tue: Kedd
@@ -4430,7 +4373,7 @@ variables:
       please_confirm: Kérjük, erősítse meg
       unavailable: Unavailable
       no_name: No name
-    IDN:
+    id: #Indonesian
       weekdays:
         mon: Senin
         tue: Selasa
@@ -4487,7 +4430,7 @@ variables:
       please_confirm: Mohon konfirmasi
       unavailable: Unavailable
       no_name: No name
-    ITA: #Italian
+    it: #Italian
       weekdays:
         mon: Lunedì
         tue: Martedì
@@ -4544,7 +4487,7 @@ variables:
       please_confirm: Confermare
       unavailable: Unavailable
       no_name: No name
-    LTU:
+    lt: #Lithuanian
       weekdays:
         mon: Pirmadienis
         tue: Antradienis
@@ -4601,7 +4544,7 @@ variables:
       please_confirm: Prašome patvirtinti
       unavailable: Unavailable
       no_name: No name
-    LVA:
+    lv: #Latvian
       weekdays:
         mon: Pirmdiena
         tue: Otrdiena
@@ -4658,64 +4601,7 @@ variables:
       please_confirm: Lūdzu, apstipriniet
       unavailable: Unavailable
       no_name: No name
-    NLD:
-      weekdays:
-        mon: Maandag
-        tue: Dinsdag
-        wed: Woensdag
-        thu: Donderdag
-        fri: Vrijdag
-        sat: Zaterdag
-        sun: Zondag
-      weekdays_short:
-        mon: Mon
-        tue: Tue
-        wed: Wed
-        thu: Thu
-        fri: Fri
-        sat: Sat
-        sun: Sun
-      months:
-        jan: January
-        feb: February
-        mar: March
-        apr: April
-        may: May
-        jun: June
-        jul: July
-        aug: August
-        sep: September
-        oct: October
-        nov: November
-        dec: December
-      months_short:
-        jan: Jan
-        feb: Feb
-        mar: Mar
-        apr: Apr
-        may: May
-        jun: Jun
-        jul: Jul
-        aug: Aug
-        sep: Sep
-        oct: Oct
-        nov: Nov
-        dec: Dec
-      relative_day:
-        today: Vandaag
-        tomorrow: Morgen
-        in_2_days: in 2 dagen
-        in_3_days: in 3 dagen
-        in_4_days: in 4 dagen
-      climate:
-        states:
-          "on": aan
-          "off": uit
-        heat: verwarm
-      please_confirm: Bevestig alstublieft
-      unavailable: Unavailable
-      no_name: No name
-    NOR: #Norwegian
+    nb: #Norwegian
       weekdays:
         mon: Mandag
         tue: Tirsdag
@@ -4772,7 +4658,64 @@ variables:
       please_confirm: Vennligst bekreft
       unavailable: Unavailable
       no_name: No name
-    POL: #Polish
+    nl: #Dutch
+      weekdays:
+        mon: Maandag
+        tue: Dinsdag
+        wed: Woensdag
+        thu: Donderdag
+        fri: Vrijdag
+        sat: Zaterdag
+        sun: Zondag
+      weekdays_short:
+        mon: Mon
+        tue: Tue
+        wed: Wed
+        thu: Thu
+        fri: Fri
+        sat: Sat
+        sun: Sun
+      months:
+        jan: January
+        feb: February
+        mar: March
+        apr: April
+        may: May
+        jun: June
+        jul: July
+        aug: August
+        sep: September
+        oct: October
+        nov: November
+        dec: December
+      months_short:
+        jan: Jan
+        feb: Feb
+        mar: Mar
+        apr: Apr
+        may: May
+        jun: Jun
+        jul: Jul
+        aug: Aug
+        sep: Sep
+        oct: Oct
+        nov: Nov
+        dec: Dec
+      relative_day:
+        today: Vandaag
+        tomorrow: Morgen
+        in_2_days: in 2 dagen
+        in_3_days: in 3 dagen
+        in_4_days: in 4 dagen
+      climate:
+        states:
+          "on": aan
+          "off": uit
+        heat: verwarm
+      please_confirm: Bevestig alstublieft
+      unavailable: Unavailable
+      no_name: No name
+    pl: #Polish
       weekdays:
         mon: Poniedziałek
         tue: Wtorek
@@ -4829,7 +4772,7 @@ variables:
       please_confirm: Proszę o potwierdzenie
       unavailable: Niedostępny
       no_name: Bez nazwy
-    PRT: #Portuguese
+    pt: #Portuguese
       weekdays:
         mon: Segunda-feira
         tue: Terça-feira
@@ -4886,7 +4829,7 @@ variables:
       please_confirm: Confirme, por favor
       unavailable: Indisponível
       no_name: Sem nome
-    ROU:
+    ro: #Romanian
       weekdays:
         mon: Luni
         tue: Marți
@@ -4943,7 +4886,7 @@ variables:
       please_confirm: Vă rugăm să confirmați
       unavailable: Unavailable
       no_name: No name
-    RUS:
+    ru: #Russian
       weekdays:
         mon: Понедельник
         tue: Вторник
@@ -5000,7 +4943,7 @@ variables:
       please_confirm: Пожалуйста, подтвердите
       unavailable: Unavailable
       no_name: No name
-    SVK:
+    sk: #Slovak
       weekdays:
         mon: Pondelok
         tue: Utorok
@@ -5057,7 +5000,7 @@ variables:
       please_confirm: Potvrďte, prosím
       unavailable: Unavailable
       no_name: No name
-    SVN:
+    sl: #Slovenian
       weekdays:
         mon: Ponedeljek
         tue: Torek
@@ -5114,7 +5057,7 @@ variables:
       please_confirm: Prosimo, potrdite
       unavailable: Unavailable
       no_name: No name
-    SWE: #Swedish
+    sv: #Swedish
       weekdays:
         mon: Måndag
         tue: Tisdag
@@ -5171,7 +5114,7 @@ variables:
       please_confirm: Vänligen bekräfta
       unavailable: Otillgänglig
       no_name: Inget namn
-    TUR:
+    tr: #Turkish
       weekdays:
         mon: Pazartesi
         tue: Salı
@@ -5228,7 +5171,7 @@ variables:
       please_confirm: Lütfen onaylayın
       unavailable: Unavailable
       no_name: No name
-    UKR:
+    uk: #Ukrainian
       weekdays:
         mon: Понеділок
         tue: Вівторок


### PR DESCRIPTION
Starts using the [new language selector release with HA 2023.5.0](https://www.home-assistant.io/blog/2023/05/03/release-20235/#new-assist-pipeline-and-language-selectors) and based on RFC 5646, which will increase reliability and standardization of the code and will enable language divisions (like pt-BR vs pt-PT).

BREAKING CHANGE:
- Users will have to select a language again on the Blueprint settings otherwise the automation will throw an error. 