### PR TITLE
Use `en` as fallback language

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -25,7 +25,7 @@ Since in this update lots of input to the blueprint changed, we highly recommend
 &nbsp;
 ## Breaking changes
 1. New requirement: Home Assistant 2023.5.0 or later
-2. Exisiting users will have o select again the language for the panel, otherwise the automation will throw an error in the log related to the previous language selection.
+2. Exisiting users will have o select again the language for the panel, otherwise English will be used to display strings.
 3. Removed entity `sensor.xxxxx_settings_entity` and service `esphome.xxxxx_set_settings_entity`
 
 &nbsp;

--- a/nspanel_blueprint.yaml
+++ b/nspanel_blueprint.yaml
@@ -857,6 +857,8 @@ blueprint:
               *HOME page*
 
               *Label which should be displayed (10 characters are supported)*
+
+              Note: This label is not visible on the US landscape model.
             default: []
             selector:
               text: {}
@@ -912,6 +914,8 @@ blueprint:
               *HOME page*
 
               *Label which should be displayed (10 characters are supported)*
+
+              Note: This label is not visible on the US landscape model.
             default: []
             selector:
               text: {}
@@ -3470,7 +3474,6 @@ trigger_variables:
 variables:
   ##### GENERAL #####
   blueprint_version: '3.5_dev'
-  language: !input 'language'
   date_format_temp: !input 'date_format'
   #Avoid breaking change for existing users with legacy type format
   date_format: >
@@ -3620,6 +3623,9 @@ variables:
       - "entitypage04"
 
   ##### MUI Multilingual User Interface #####
+  language_tmp: !input 'language'
+  language: '{{ language_tmp if language_tmp is string and language_tmp in ["bg", "hr", "cs", "da", "nl", "et", "fi", "fr", "de", "el", "he", "hu", "id", "it", "lv", "lt", "nb", "pl", "pt", "ro", "ru", "sk", "sl", "es", "sv", "tr", "uk"] else "en" }}'
+
   mui:
     bg: #Bulgarian
       weekdays:


### PR DESCRIPTION
Uses English if a non valid language is selected (like when using legacy language selection).