### PR TITLE
Select wake-up page

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -39,6 +39,7 @@ Since in this update lots of input to the blueprint changed, we highly recommend
 7. API status indication on the panel ([#5ff5d35](https://github.com/Blackymas/NSPanel_HA_Blueprint/commit/5ff5d35833be1a1cf9ca0f570662456058980024))
 8. Light & cover settings pages will show only the supported features (#896)
 9. New "Fan speed page" (#897)
+10. Select wake-up page (#898)
    
 &nbsp;
 ## Details of all changes
@@ -93,7 +94,15 @@ Now when long press a button conneted to a light or a cover, the detailed light 
 ### 9. New "Fan speed page"
 If you have a connected fan supporting speed control, now you wilhave all the speed control settings in your panel. Just add the new fan to one of the buttons pages or to the hardware buttons and a long press on those buttons will pop up the new "Fan speed page":
 ![image](https://github.com/Blackymas/NSPanel_HA_Blueprint/assets/94725493/4167928e-6822-4db6-a24b-f8a1d52806f5)
+&nbsp;
+### 10. Select wake-up page
+Now you can select the wake-up page on the blueprint settings:
 
+![image](https://github.com/Blackymas/NSPanel_HA_Blueprint/assets/94725493/30b54682-f1ca-43ac-80af-f89459a6ffd7)
+
+This selected page will be shown after a boot (after the boot page) and with a touch in the screen when on screen saver page. After showing this wake-up page, all the previous behavior for closing the page (with a click or after a timeout) will be the same.
+
+&nbsp;
 ## Next topics we are currently working on
 See here: https://github.com/Blackymas/NSPanel_HA_Blueprint/labels/roadmap
 

--- a/nspanel_blueprint.yaml
+++ b/nspanel_blueprint.yaml
@@ -122,6 +122,39 @@ blueprint:
                 min: 0
                 max: 100
 
+          wakeup_page:
+            name: Wake-up page
+            description: >
+              *SYSTEM settings*
+
+              *Select the page to show when the system wakes up with a touch in the screen.*
+            default: '0'
+            selector:
+              select:
+                multiple: false
+                options:
+                  - label: 'Home page (default)'
+                    value: '0'
+                  - label: 'Buttons page 01'
+                    value: '12'
+                  - label: 'Buttons page 02'
+                    value: '13'
+                  - label: 'Buttons page 03'
+                    value: '14'
+                  - label: 'Buttons page 04'
+                    value: '15'
+                  - label: 'Entities page 01'
+                    value: '18'
+                  - label: 'Entities page 02'
+                    value: '19'
+                  - label: 'Entities page 03'
+                    value: '20'
+                  - label: 'Entities page 04'
+                    value: '21'
+                  - label: 'QR code page'
+                    value: '17'
+
+
     ##### WEATHER - Page Home / Weather 01-04 #####
         ##### PLACEHOLDER ######################################################################
           placeholder01:
@@ -6122,12 +6155,17 @@ action:
           - *refresh-datetime
 
           ##### NSPanel boot init finished and jump to Home Page#####
-          - *delay-default
-          - &jump_page_home
-            service: '{{ nextion.command.printf }}'
-            data:
-              cmd: "page {{ page.home }}"
-            continue_on_error: true
+          - &jump_wakeup_page
+            if: '{{ true }}'
+            then:
+              - &variables_wakeup_page
+                variables:
+                  wakeup_page: !input wakeup_page
+              - *delay-default
+              - service: '{{ nextion.command.printf }}'
+                data:
+                  cmd: "page {{ wakeup_page if is_number(wakeup_page) else page.home }}"
+                continue_on_error: true
 
       ##### NSPanel event #####
       - alias: NSPanel Event
@@ -7537,7 +7575,7 @@ action:
                                           continue_on_error: true
                             #else:
                               ##### Return to Home page in case is not a climate entity #####
-                              #- *jump_page_home
+                              #- *jump_wakeup_page
 
                       ## ENTITY PAGES 01 - 04 ##
                       - alias: Entity pages
@@ -8137,6 +8175,19 @@ action:
                               component: 'qrcode_value'
                               message: '{{ qrcode_value }}'
                             continue_on_error: true
+
+                      ## PAGE Screen saver ##
+                      - alias: Screen saver page
+                        conditions: '{{ nspanel_event.page == page.screensaver }}'
+                        sequence:
+                          ##### Set wake-up screen #####
+                          - *variables_wakeup_page
+                          - service: '{{ nextion.command.value }}'
+                            data:
+                              component: orign
+                              message: "{{ wakeup_page | int(0) if is_number(wakeup_page) else 0 }}"
+                            continue_on_error: true
+                          - *delay-default
 
               - alias: light settings # rgb_color, brightness, color_temp
                 conditions:
@@ -8916,7 +8967,7 @@ action:
             data: {}
             continue_on_error: true
 
-      ##### Wake-up when slee mode is disabled #####
+      ##### Wake-up when sleep mode is disabled #####
       - alias: Sleep mode changed
         conditions:
           - condition: trigger
@@ -8925,7 +8976,7 @@ action:
           - "{{ trigger.event.data.old_state.state == 'on' }}"
           - "{{ trigger.event.data.new_state.state == 'off' }}"
         sequence:
-          - *jump_page_home
+          - *jump_wakeup_page
 
 #############################################################
 ##### CLOSE - Action #####


### PR DESCRIPTION
Users will be able to select the wake-up page on the blueprint inputs. This selected page will be shown after a boot (after the boot page) and with a touch in the screen when on screen saver page. After showing this wake-up page, all the previous behavior for closing the page (with a click or after a timeout) will be the same.

Solves #576 
Solves #612 
Solves #801 
Probably improves for https://github.com/Blackymas/NSPanel_HA_Blueprint/discussions/718#discussioncomment-5715670