### PR TITLE
Dev

### DIFF
--- a/nspanel_blueprint.yaml
+++ b/nspanel_blueprint.yaml
@@ -7658,6 +7658,8 @@ action:
                                                   if repeat.item.icon.split(":") | count > 0
                                                   else repeat.item.icon
                                                 }}
+                                              {% elif state_attr(repeat.item.entity, "icon") | default("") not in ["unavailable", "unknown", "", None] and all_icons[state_attr(repeat.item.entity, "icon").split(":")[1]] != null %}
+                                                {{ all_icons[state_attr(repeat.item.entity, "icon").split(":")[1]] | default(all_icons.unknown) }}
                                               {% elif repeat.item.entity and repeat.item.entity.split(".") | count > 1 %}
                                                 {{ nextion.icon.domain[repeat.item.entity.split(".")[0] if repeat.item.entity else "unknown"] }}
                                               {% else %}{{ nextion.icon.domain.unknown }}


### PR DESCRIPTION
this shows entity icons on the 4 overview pages,
maybe it's worth also doing this on the detail pages but that would be a next step.

it's tested and working.
even when the icon is not available in all_icons
then the domain icon will be shown. the null check took me some time to figure out.