### PR TITLE
fix button picture fallback

### DIFF
--- a/nspanel_esphome_core.yaml
+++ b/nspanel_esphome_core.yaml
@@ -1742,8 +1742,8 @@ script:
           if (relay_2->state) disp1->set_component_text_printf("home.icon_top_02", "%s", id(home_relay2_icon).c_str());
             else disp1->set_component_text_printf("home.icon_top_02", "\uFFFF");
           // Hardware buttons - Fallback mode
-          if (relay_1->state and relay1_local->state) disp1->send_command_printf("home.left_bt_pic.val=%i", (relay_1->state) ? 1 : 0);
-          if (relay_2->state and relay2_local->state) disp1->send_command_printf("home.right_bt_pic.val=%i", (relay_2->state) ? 1 : 0);
+          if (relay1_local->state) disp1->send_command_printf("home.left_bt_pic.val=%i", (relay_1->state) ? 1 : 0);
+          if (relay2_local->state) disp1->send_command_printf("home.right_bt_pic.val=%i", (relay_2->state) ? 1 : 0);
 
   - id: refresh_wifi_icon
     mode: restart


### PR DESCRIPTION
when localfallback is enabled,
and the switch is turned off
relay_1-> state = off(false)
so the action won't be applied and it takes a second for the HA automation to update the icon.

so this check should not be here, it should only for fallback and then choose 1/0 based on the state.

remark(I cannot test off to on atm as my custom change then opens the detail page, but I have no reason to think this won't work)