### PR TITLE
Dev Allow to set upper and lower set point for embedded thermostat

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -332,13 +332,13 @@ You also have to set **Display Brightness Sleep** at the device's page (**Settin
 Discover what's next and what we are working on right now in our [Milestones](https://github.com/Blackymas/NSPanel_HA_Blueprint/milestones?direction=asc&sort=due_date)
 
 ## Special thanks to
-
-- @bluefoxlee - For the CJK fonts and all the support with #1359.
+- @bluefoxlee - For the CJK fonts and all the support with #1359
 - @Floppe - Fix entity pages labels, #1455
 - @tikismoke - Customization guide: Exposing relay fallback switch to Home Assistant, #1537
+- @andythomas - Allow to set upper and lower set points for embedded thermostat, #1573
+- And to all users who helped with the tests during development and beta.
 
 ## Previous releases
-
 - [v4.1.4 - Support to Home Assistant 2023.12.0](https://github.com/Blackymas/NSPanel_HA_Blueprint/releases/tag/v4.1.4)
 - [v4.1.3 - Bug fixes](https://github.com/Blackymas/NSPanel_HA_Blueprint/releases/tag/v4.1.3)
 - [v4.1.2 - Bug fixes and minor enhancements](https://github.com/Blackymas/NSPanel_HA_Blueprint/releases/tag/v4.1.2)

--- a/advanced/esphome/nspanel_esphome_addon_climate_base.yaml
+++ b/advanced/esphome/nspanel_esphome_addon_climate_base.yaml
@@ -21,6 +21,10 @@ substitutions:
   temp_step: "0.5"
   target_low: "18"
   target_high: "24"
+  cool_deadband: "0.5"  # Temperature delta before engaging cooling
+  cool_overrun: "0.5"   # Temperature delta before disengaging cooling
+  heat_deadband: "0.5"  # Temperature delta before engaging heat
+  heat_overrun: "0.5"   # Temperature delta before disengaging heat
 
   ##### DO NOT CHANGE THIS #####
   addon_climate_cool: "false"

--- a/docs/addon_climate.md
+++ b/docs/addon_climate.md
@@ -74,6 +74,11 @@ target_high|Optional|Number representing a temperature in the selected unit|`24`
 temp_min|Optional|Number representing a temperature in the selected unit|*cool: `15`*<br>*heat: `7`*<br>*dual: `7`* |The minimum temperature the climate device can reach. Used to set the range of the frontend gauge.
 temp_max|Optional|Number representing a temperature in the selected unit|*cool: `45`*<br>*heat: `35`*<br>*dual: `45`* |The maximum temperature the climate device can reach. Used to set the range of the frontend gauge.
 temp_step|Optional|Number representing a temperature in the selected unit|`0.5`|The granularity with which the target temperature can be controlled.
+cool_deadband|Optional|Number representing a temperature hysteresis in the selected unit|`0.5`|The minimum temperature differential (temperature above the set point) before engaging cooling.
+cool_overrun|Optional|Number representing a temperature hysteresis in the selected unit|`0.5`|The minimum temperature differential (cooling beyond the set point) before disengaging cooling.
+heat_deadband|Optional|Number representing a temperature hysteresis in the selected unit|`0.5`|The minimum temperature differential (temperature below the set point) before engaging heat.
+heat_overrun|Optional|Number representing a temperature hysteresis in the selected unit|`0.5`|The minimum temperature differential (heating beyond the set point) before disengaging heat.
+
 <!-- markdownlint-enable MD013 MD033 -->
 
 - All values must be delimited with `""`
@@ -95,11 +100,13 @@ substitutions:
     
   # Add-on configuration (if needed)
   ## Add-on climate
-  cooler_relay: "1"  # Possible values: "1" or "2"
-  temp_units: "°F"   # Temperatures in Fahrenheit
-  temp_min: "40"     # Min supported temperature is 40°F
-  temp_max: "80"     # Max supported temperature is 80°F
-  temp_step: "1"     # Temperature granularity is 1°F
+  cooler_relay: "1"     # Possible values: "1" or "2"
+  temp_units: "°F"      # Temperatures in Fahrenheit
+  temp_min: "40"        # Min supported temperature is 40°F
+  temp_max: "80"        # Max supported temperature is 80°F
+  temp_step: "1"        # Temperature granularity is 1°F
+  cool_deadband: "1.2"  # Temperature delta before engaging cooling
+  cool_overrun: "1.2"   # Temperature delta before disengaging cooling
 
 # Customization area
 ##### My customization - Start #####
@@ -142,9 +149,8 @@ substitutions:
   temp_min: "40"        # Min supported temperature is 40°F
   temp_max: "80"        # Max supported temperature is 80°F
   temp_step: "1"        # Temperature granularity is 1°F
-  heat_deadband: "0.5"  # Temperature delta before engaging heat
-  heat_overrun: "0.5"   # Temperature delta before disengaging heat
-
+  heat_deadband: "1.2"  # Temperature delta before engaging heat
+  heat_overrun: "1.2"   # Temperature delta before disengaging heat
 
 # Customization area
 ##### My customization - Start #####
@@ -182,12 +188,16 @@ substitutions:
     
   # Add-on configuration (if needed)
   ## Add-on climate
-  heater_relay: "1"  # Possible values: "1" or "2"
-  cooler_relay: "2"  # Possible values: "1" or "2"
-  temp_units: "°F"   # Temperatures in Fahrenheit
-  temp_min: "40"     # Min supported temperature is 40°F
-  temp_max: "80"     # Max supported temperature is 80°F
-  temp_step: "1"     # Temperature granularity is 1°F
+  heater_relay: "1"     # Possible values: "1" or "2"
+  cooler_relay: "2"     # Possible values: "1" or "2"
+  temp_units: "°F"      # Temperatures in Fahrenheit
+  temp_min: "40"        # Min supported temperature is 40°F
+  temp_max: "80"        # Max supported temperature is 80°F
+  temp_step: "1"        # Temperature granularity is 1°F
+  cool_deadband: "1.2"  # Temperature delta before engaging cooling
+  cool_overrun: "1.2"   # Temperature delta before disengaging cooling
+  heat_deadband: "1.2"  # Temperature delta before engaging heat
+  heat_overrun: "1.2"   # Temperature delta before disengaging heat
 
 # Customization area
 ##### My customization - Start #####

--- a/docs/addon_climate.md
+++ b/docs/addon_climate.md
@@ -142,8 +142,8 @@ substitutions:
   temp_min: "40"        # Min supported temperature is 40°F
   temp_max: "80"        # Max supported temperature is 80°F
   temp_step: "1"        # Temperature granularity is 1°F
-  cold_tolerance: "0.5" # lower set point
-  hot_tolerance: "0.5"  # upper set point
+  heat_deadband: "0.5"  # Temperature delta before engaging heat
+  heat_overrun: "0.5"   # Temperature delta before disengaging heat
 
 
 # Customization area

--- a/docs/addon_climate.md
+++ b/docs/addon_climate.md
@@ -137,11 +137,14 @@ substitutions:
     
   # Add-on configuration (if needed)
   ## Add-on climate
-  heater_relay: "1"  # Possible values: "1" or "2"
-  temp_units: "°F"   # Temperatures in Fahrenheit
-  temp_min: "40"     # Min supported temperature is 40°F
-  temp_max: "80"     # Max supported temperature is 80°F
-  temp_step: "1"     # Temperature granularity is 1°F
+  heater_relay: "1"     # Possible values: "1" or "2"
+  temp_units: "°F"      # Temperatures in Fahrenheit
+  temp_min: "40"        # Min supported temperature is 40°F
+  temp_max: "80"        # Max supported temperature is 80°F
+  temp_step: "1"        # Temperature granularity is 1°F
+  cold_tolerance: "0.5" # lower set point
+  hot_tolerance: "0.5"  # upper set point
+
 
 # Customization area
 ##### My customization - Start #####

--- a/nspanel_esphome_addon_climate_cool.yaml
+++ b/nspanel_esphome_addon_climate_cool.yaml
@@ -19,6 +19,8 @@ climate:
   - id: !extend thermostat_embedded
     min_cooling_off_time: ${min_off_time}s
     min_cooling_run_time: ${min_run_time}s
+    cool_deadband: ${heat_deadband} ${temp_units}
+    cool_overrun: ${heat_overrun} ${temp_units}
     cool_action:
       - switch.turn_on: relay_${cooler_relay}
     preset:

--- a/nspanel_esphome_addon_climate_dual.yaml
+++ b/nspanel_esphome_addon_climate_dual.yaml
@@ -18,6 +18,10 @@ climate:
     min_heating_off_time: ${min_off_time}s
     min_cooling_run_time: ${min_run_time}s
     min_heating_run_time: ${min_run_time}s
+    cool_deadband: ${heat_deadband} ${temp_units}
+    cool_overrun: ${heat_overrun} ${temp_units}
+    heat_deadband: ${heat_deadband} ${temp_units}
+    heat_overrun: ${heat_overrun} ${temp_units}
     cool_action:
       - switch.turn_on: relay_${cooler_relay}
     heat_action:

--- a/nspanel_esphome_addon_climate_heat.yaml
+++ b/nspanel_esphome_addon_climate_heat.yaml
@@ -10,6 +10,8 @@
 substitutions:
   ### Local thermostat defaults ###
   temp_max: "25"
+  cold_tolerance: "0.5"
+  hot_tolerance: "0.5"
 
   ##### DO NOT CHANGE THIS #####
   addon_climate_heat: "true"
@@ -19,6 +21,8 @@ climate:
   - id: !extend thermostat_embedded
     min_heating_off_time: ${min_off_time}s
     min_heating_run_time: ${min_run_time}s
+    heat_deadband: ${cold_tolerance}
+    heat_overrun: ${hot_tolerance}
     heat_action:
       - switch.turn_on: relay_${heater_relay}
     preset:

--- a/nspanel_esphome_addon_climate_heat.yaml
+++ b/nspanel_esphome_addon_climate_heat.yaml
@@ -10,8 +10,6 @@
 substitutions:
   ### Local thermostat defaults ###
   temp_max: "25"
-  heat_deadband: "0.5"
-  heat_overrun: "0.5"
 
   ##### DO NOT CHANGE THIS #####
   addon_climate_heat: "true"
@@ -21,8 +19,8 @@ climate:
   - id: !extend thermostat_embedded
     min_heating_off_time: ${min_off_time}s
     min_heating_run_time: ${min_run_time}s
-    heat_deadband: ${heat_deadband}
-    heat_overrun: ${heat_overrun}
+    heat_deadband: ${heat_deadband} ${temp_units}
+    heat_overrun: ${heat_overrun} ${temp_units}
     heat_action:
       - switch.turn_on: relay_${heater_relay}
     preset:

--- a/nspanel_esphome_addon_climate_heat.yaml
+++ b/nspanel_esphome_addon_climate_heat.yaml
@@ -10,8 +10,8 @@
 substitutions:
   ### Local thermostat defaults ###
   temp_max: "25"
-  cold_tolerance: "0.5"
-  hot_tolerance: "0.5"
+  heat_deadband: "0.5"
+  heat_overrun: "0.5"
 
   ##### DO NOT CHANGE THIS #####
   addon_climate_heat: "true"
@@ -21,8 +21,8 @@ climate:
   - id: !extend thermostat_embedded
     min_heating_off_time: ${min_off_time}s
     min_heating_run_time: ${min_run_time}s
-    heat_deadband: ${cold_tolerance}
-    heat_overrun: ${hot_tolerance}
+    heat_deadband: ${heat_deadband}
+    heat_overrun: ${heat_overrun}
     heat_action:
       - switch.turn_on: relay_${heater_relay}
     preset:


### PR DESCRIPTION
Introducing `hot_tolerance` and `cold_tolerance` for the embedded thermostat (naming similar to [HA generic thermostat](https://www.home-assistant.io/integrations/generic_thermostat/))