### PR TITLE
[BUG FIX] Fixes the incorrect labelling of the entity pages alignment on US Portrait.

### DIFF
--- a/nspanel_blueprint.yaml
+++ b/nspanel_blueprint.yaml
@@ -2772,11 +2772,11 @@ blueprint:
               select:
                 multiple: false
                 options:
-                  - label: "Right (default)"
+                  - label: "Left (default)"
                     value: "0"
                   - label: "Center"
                     value: "1"
-                  - label: "Left"
+                  - label: "Right"
                     value: "2"
       ##### Entity page 01 - Entities #####
         ##### PLACEHOLDER ######################################################################


### PR DESCRIPTION
On US Portrait 0 is left align, 1 is center and 2 is right align.

Need to confirm that this configuration is the same for EU and US Landscape - it may be that the Nextion HMI is different for US Portrait because of rotation.