### PR TITLE
Fix for Lights with no brightness supported_features

### DIFF
--- a/nspanel_blueprint.yaml
+++ b/nspanel_blueprint.yaml
@@ -8473,9 +8473,13 @@ action:
                                             btn_bri_txt: >  # Buttons value (brightness, temperature, etc.)
                                               {% if not entity.has_value %} 0
                                               {% elif entity.domain == "light" and entity.state == "on" %}
-                                                {% set entity_brightness = state_attr(entity.id, "brightness") | default(None) %}
-                                                {% set entity_brightness_index = entity_brightness/255 if is_number(entity_brightness) else 0 %}
-                                                {{ (entity_brightness_index*100) | round(0) }}%
+                                                {% if (state_attr(entity, 'supported_features') and 1) == 0 %}
+                                                  {{ all_icons.blank }}
+                                                {% else %}
+                                                  {% set entity_brightness = state_attr(entity.id, "brightness") | default(None) %}
+                                                  {% set entity_brightness_index = entity_brightness/255 if is_number(entity_brightness) else 0 %}
+                                                  {{ (entity_brightness_index*100) | round(0) }}%
+                                                {% endif %}
                                               {% elif entity.domain == "fan" and entity.state == "on" and state_attr(entity.id, "percentage") != None %}
                                                 {{ state_attr(entity.id, "percentage") | round(0, default=0) }}%
                                               {% elif

--- a/nspanel_blueprint.yaml
+++ b/nspanel_blueprint.yaml
@@ -2772,11 +2772,11 @@ blueprint:
               select:
                 multiple: false
                 options:
-                  - label: "Left (default)"
+                  - label: "Right (default)"
                     value: "0"
                   - label: "Center"
                     value: "1"
-                  - label: "Right"
+                  - label: "Left"
                     value: "2"
       ##### Entity page 01 - Entities #####
         ##### PLACEHOLDER ######################################################################

--- a/nspanel_blueprint.yaml
+++ b/nspanel_blueprint.yaml
@@ -2772,11 +2772,11 @@ blueprint:
               select:
                 multiple: false
                 options:
-                  - label: "Right (default)"
+                  - label: "Left (default)"
                     value: "0"
                   - label: "Center"
                     value: "1"
-                  - label: "Left"
+                  - label: "Right"
                     value: "2"
       ##### Entity page 01 - Entities #####
         ##### PLACEHOLDER ######################################################################

--- a/nspanel_blueprint.yaml
+++ b/nspanel_blueprint.yaml
@@ -8473,13 +8473,9 @@ action:
                                             btn_bri_txt: >  # Buttons value (brightness, temperature, etc.)
                                               {% if not entity.has_value %} 0
                                               {% elif entity.domain == "light" and entity.state == "on" %}
-                                                {% if (entity.supported_features and 1) == 0 %}
-                                                  {{ all_icons.blank }}
-                                                {% else %}
-                                                  {% set entity_brightness = state_attr(entity.id, "brightness") | default(None) %}
-                                                  {% set entity_brightness_index = entity_brightness/255 if is_number(entity_brightness) else 0 %}
-                                                  {{ (entity_brightness_index*100) | round(0) }}%
-                                                {% endif %}
+                                                {% set entity_brightness = state_attr(entity.id, "brightness") | default(None) %}
+                                                {% set entity_brightness_index = entity_brightness/255 if is_number(entity_brightness) else 0 %}
+                                                {{ (entity_brightness_index*100) | round(0) }}%
                                               {% elif entity.domain == "fan" and entity.state == "on" and state_attr(entity.id, "percentage") != None %}
                                                 {{ state_attr(entity.id, "percentage") | round(0, default=0) }}%
                                               {% elif
@@ -8505,7 +8501,7 @@ action:
                                             icon: '{{ entity.icon }}'
                                             icon_color: '{{ entity.icon_color }}'
                                             icon_font: '{{ button_pages_icon_size if is_number(button_pages_icon_size) else 8 }}'
-                                            bri: '{{ btn_bri_txt }}'
+                                            bri: '{{ btn_bri_txt if btn_bri_txt and btn_bri_txt != "0%" else "" }}'
                                             label: '{{ entity.name }}'
                                           continue_on_error: true
                                         - if: >

--- a/nspanel_blueprint.yaml
+++ b/nspanel_blueprint.yaml
@@ -8473,7 +8473,7 @@ action:
                                             btn_bri_txt: >  # Buttons value (brightness, temperature, etc.)
                                               {% if not entity.has_value %} 0
                                               {% elif entity.domain == "light" and entity.state == "on" %}
-                                                {% if (state_attr(entity, 'supported_features') and 1) == 0 %}
+                                                {% if (entity.supported_features and 1) == 0 %}
                                                   {{ all_icons.blank }}
                                                 {% else %}
                                                   {% set entity_brightness = state_attr(entity.id, "brightness") | default(None) %}


### PR DESCRIPTION
Inserts all_icons.blank for `bri` if the light.supported_features does not include SUPPORT_BRIGHTNESS (bitmask 1).

This prevents the otherwise nonsense result of 0% showing here instead.

Addresses #1623