### PR TITLE
Add Dutch/Italian date format

### DIFF
--- a/nspanel_blueprint.yaml
+++ b/nspanel_blueprint.yaml
@@ -98,6 +98,8 @@ blueprint:
                     value: '%A %-d-%-m'
                   - label: Weekday M-D (ex. "Friday 3-22")
                     value: '%A %-m-%-d'
+                  - label: Weekday, DD-MM (ex. "Friday, 22-03")
+                    value: "%A, %d-%m"
 
           time_format:
             name: Time Format


### PR DESCRIPTION
add Dutch/Italian date format,
Germany and Poland use a . where the Netherlands and Italian use a - both including leading 0

Maybe making it completely variable would be better, but I'm not sure it's user friently enough.