### PR TITLE
Documentation Enhancement: Add note about bluetooth proxy RAM usage

### DIFF
--- a/docs/customization.md
+++ b/docs/customization.md
@@ -514,10 +514,14 @@ esp32:
 > The [ESP32 Platform](#framework-esp-idf) component should be configured to use the `esp-idf` framework,
 > as the `arduino` framework uses significantly more memory and performs poorly with the Bluetooth proxy enabled.
 
-> [!NOTE]  
-<!-- markdownlint-disable MD013 -->
-> The Bluetooth proxy component uses a significant amount of device RAM (<10k RAM free). Enabling this with other customizations/ components enabled may result in crashes due to the device running out of memory. It is known that https connections are erratic due to insufficient memory and there can be issues flashing TFT locally due to the device running out of RAM. You can either: (1) flash the device (removing bluetooth proxy) while updating TFT or, (2) flash the device from a local (http) source with a low baud rate (<9600) that will not cause an out of memory crash - do note that this will take much longer to update (~ 10 minutes).
-<!-- markdownlint-enable MD013 -->
+> [!NOTE]
+> The Bluetooth proxy component significantly reduces device RAM, leaving less than 10k RAM free.
+> Enabling this with additional customizations/components may lead to crashes due to low memory.
+> HTTPS connections might be erratic, and local TFT flashing could fail due to insufficient RAM.
+>
+> Solutions include:
+> 1. Flash the device (remove Bluetooth proxy) while updating TFT.
+> 2. Flash from a local (HTTP) source at a low baud rate (9600 or lower) to avoid memory crashes. This method is slower, taking over 10 minutes.
 <!-- markdownlint-enable MD028 -->
 ```yaml
 # Enable Bluetooth proxy

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -509,13 +509,16 @@ esp32:
 ```
 
 ### Bluetooth proxy
+<!-- markdownlint-disable MD028 -->
 > [!IMPORTANT]
 > The [ESP32 Platform](#framework-esp-idf) component should be configured to use the `esp-idf` framework,
 > as the `arduino` framework uses significantly more memory and performs poorly with the Bluetooth proxy enabled.
 
 > [!NOTE]  
+<!-- markdownlint-disable MD013 -->
 > The Bluetooth proxy component uses a significant amount of device RAM (<10k RAM free). Enabling this with other customizations/ components enabled may result in crashes due to the device running out of memory. It is known that https connections are erratic due to insufficient memory and there can be issues flashing TFT locally due to the device running out of RAM. You can either: (1) flash the device (removing bluetooth proxy) while updating TFT or, (2) flash the device from a local (http) source with a low baud rate (<9600) that will not cause an out of memory crash - do note that this will take much longer to update (~ 10 minutes).
-
+<!-- markdownlint-enable MD013 -->
+<!-- markdownlint-enable MD028 -->
 ```yaml
 # Enable Bluetooth proxy
 bluetooth_proxy:

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -513,6 +513,9 @@ esp32:
 > The [ESP32 Platform](#framework-esp-idf) component should be configured to use the `esp-idf` framework,
 > as the `arduino` framework uses significantly more memory and performs poorly with the Bluetooth proxy enabled.
 
+> [!NOTE]  
+> The Bluetooth proxy component uses a significant amount of device RAM (<10k RAM free). Enabling this with other customizations/ components enabled may result in crashes due to the device running out of memory. It is known that https connections are erratic due to insufficient memory and there can be issues flashing TFT locally due to the device running out of RAM. You can either: (1) flash the device (removing bluetooth proxy) while updating TFT or, (2) flash the device from a local (http) source with a low baud rate (<9600) that will not cause an out of memory crash - do note that this will take much longer to update (~ 10 minutes).
+
 ```yaml
 # Enable Bluetooth proxy
 bluetooth_proxy:


### PR DESCRIPTION
Updates the customization documentation to note the high RAM usage of bluetooth proxy (including 2 work arounds for TFT flashing RAM issues).