### PR TITLE
Update nspanel_blueprint.yaml

### DIFF
--- a/nspanel_blueprint.yaml
+++ b/nspanel_blueprint.yaml
@@ -8252,7 +8252,7 @@ action:
                           timezone: !input timezone
 
                       ##### Timezone #####
-                      - if: '{{ timezone is string and timezone | length > 1 }}'
+                      - if: '{{ timezone is string and len(timezone) > 1 }}'
                         then:
                           - variables:
                               timezone_code: >


### PR DESCRIPTION
fixes "Error: TypeError: '>' not supported between instances of 'list' and 'int'"