### PR TITLE
Update chip climate ID in documentation

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -853,7 +853,7 @@ automation:
 - **Description**: Icon representing the state of the main climate entity.
 - **Type**: Icon only with no touch commands.
 - **Availability**: Global (available even when page is not visible).
-- **Ids**: `home.chip_relay1` and `home.chip_relay2`.
+- **Ids**: `home.chip_climate`.
 
 ### Home Page - Custom buttons
 ![Image](pics/Nextion_Components_Home_Custom_Buttons_EU.png)


### PR DESCRIPTION
Climate chip id was the same as relay chips ids. Looking at the code it looks the correct id is home.chip_climate.