### PR TITLE
Fixing occasional boot loop in Relay handling

### DIFF
--- a/esphome/nspanel_esphome_standard_hw_relays.yaml
+++ b/esphome/nspanel_esphome_standard_hw_relays.yaml
@@ -94,14 +94,16 @@ script:
               ESP_LOGV("${TAG_STANDARD_HW_RELAYS}", "HW Relay - Chip new val");
               id(home_relay1_icon_color) = color565(color);
               copyStringToCharArray(id(home_relay1_icon), txt);
-              display_component_update_visibility->execute(id(relay1_icon), relay_1->state);
+              if (id(relay1_icon))
+                display_component_update_visibility->execute(id(relay1_icon), relay_1->state);
               ESP_LOGV("${TAG_STANDARD_HW_RELAYS}", "HW Relay - Chip set");
             }
             else if (component == "chip_relay2") {
               ESP_LOGV("${TAG_STANDARD_HW_RELAYS}", "HW Relay - Chip new val");
               id(home_relay2_icon_color) = color565(color);
               copyStringToCharArray(id(home_relay2_icon), txt);
-              display_component_update_visibility->execute(id(relay2_icon), relay_2->state);
+              if (id(relay2_icon))
+                display_component_update_visibility->execute(id(relay2_icon), relay_2->state);
               ESP_LOGV("${TAG_STANDARD_HW_RELAYS}", "HW Relay - set");
             }
           }
@@ -126,8 +128,10 @@ script:
     mode: restart
     then:
       - lambda: |-
-          display_component_update_visibility->execute(id(relay1_icon), relay_1->state);
-          display_component_update_visibility->execute(id(relay2_icon), relay_2->state);
+          if (id(relay1_icon))
+            display_component_update_visibility->execute(id(relay1_icon), relay_1->state);
+          if (id(relay2_icon))
+            display_component_update_visibility->execute(id(relay2_icon), relay_2->state);
 
   - id: !extend set_var_bool
     then:

--- a/nspanel_blueprint.yaml
+++ b/nspanel_blueprint.yaml
@@ -9008,7 +9008,7 @@ actions:
                               - variables:
                                   relay1_icon: !input relay01_icon
                                   relay1_icon_color: !input relay01_icon_color
-                                  relay2_icon: !input relay01_icon
+                                  relay2_icon: !input relay02_icon
                                   relay2_icon_color: !input relay02_icon_color
                                   default_icon_color: *color_home_chip
 


### PR DESCRIPTION
When trying to upgrade to 4.4.0, looks like occasionally the id(relay1_icon) is not set up properly before it is accessed. This change tries to make sure the system doesn't end up in a boot loop in this case.

Also there's a typo in the Blueprint that made changing the second relay icon not possible