### PR TITLE
Fix crash during logging of component actions

### DIFF
--- a/esphome/nspanel_esphome_core_hw_display.yaml
+++ b/esphome/nspanel_esphome_core_hw_display.yaml
@@ -55,7 +55,14 @@ api:
             } else {
               ESP_LOGD("${TAG_CORE_HW_DISPLAY}", "  txt:     null (len=0)");
             }
-            ESP_LOGD("${TAG_CORE_HW_DISPLAY}", "  color:   %" PRIu16, color565(color));
+            if (color.size() == 3 and
+                color[0] >= 0 and color[0] <= UINT8_MAX and
+                color[1] >= 0 and color[1] <= UINT8_MAX and
+                color[2] >= 0 and color[2] <= UINT8_MAX) {
+              ESP_LOGD("${TAG_CORE_HW_DISPLAY}", "  color:   %" PRIu16, color565(color));
+            } else {
+              ESP_LOGD("${TAG_CORE_HW_DISPLAY}", "  color:   invalid");
+            }
             ESP_LOGD("${TAG_CORE_HW_DISPLAY}", "  font:    %" PRIi32, font);
             ESP_LOGD("${TAG_CORE_HW_DISPLAY}", "  visible: %s", YESNO(visible));
             #endif


### PR DESCRIPTION
If the color was outside of allowed parameters this caused a crash on the button & settings page (at least for me).