### PR TITLE
[4.4.0] Split wakeup and dim, so the watchdog would not force wakeup every minute

### DIFF
--- a/esphome/nspanel_esphome_core_hw_display_timers.yaml
+++ b/esphome/nspanel_esphome_core_hw_display_timers.yaml
@@ -30,7 +30,7 @@ binary_sensor:
             if (hw_button_wakeup->state) {
               if (current_page_id == ${PAGE_ID_SCREENSAVER})
                 goto_page_id->execute(get_page_id(wakeup_page_name->state.c_str()), false);
-              timer_dim->execute();
+              timer_wakeup->execute();
               timer_sleep->execute();
             }
 
@@ -57,7 +57,7 @@ number:
         - lambda: |-
             if (current_page_id != ${PAGE_ID_SCREENSAVER}) {
               disp1->set_backlight_brightness(x / 100.0f);
-              timer_dim->execute();
+              timer_wakeup->execute();
               timer_sleep->execute();
             }
 
@@ -91,7 +91,7 @@ number:
     unit_of_measurement: "s"
     on_value:
       then:
-        - script.execute: timer_dim
+        - script.execute: timer_wakeup
 
   - id: timeout_sleep
     name: Timeout - Sleep
@@ -124,7 +124,7 @@ script:
           if (reset_timers and page_id != ${PAGE_ID_SCREENSAVER}) {
             if (page_id != ${PAGE_ID_HOME})
               timer_page->execute();
-            timer_dim->execute();
+            timer_wakeup->execute();
             timer_sleep->execute();
           }
 
@@ -132,6 +132,7 @@ script:
     then:
       - lambda: |-
           timer_dim->stop();
+          timer_wakeup->stop();
           timer_page->stop();
           timer_reset_all->stop();
           timer_sleep->stop();
@@ -152,7 +153,7 @@ script:
     mode: restart
     then:
       - lambda: |-
-          timer_dim->execute();
+          timer_wakeup->execute();
           timer_page->execute();
           timer_sleep->execute();
 
@@ -171,7 +172,7 @@ script:
                   goto_page_id->execute(${PAGE_ID_HOME}, false);
                 }
 
-  - id: timer_dim        # Handles the brightness dimming after a timeout
+  - id: timer_wakeup
     mode: restart
     then:
       - lambda: |-
@@ -179,7 +180,12 @@ script:
               current_page_id != ${PAGE_ID_BOOT}) {
             ESP_LOGD("${TAG_HW_DISPLAY_TIMERS}", "Wake on page: %s", page_names[current_page_id]);
             disp1->set_backlight_brightness(display_brightness->state / 100.0f);
+            timer_dim->execute();
           }
+
+  - id: timer_dim        # Handles the brightness dimming after a timeout
+    mode: restart
+    then:
       - if:
           condition:
             - number.in_range:


### PR DESCRIPTION
`timer_dim` was used not just to initiate the dimming, but also to actually wake up the panel. However since `timer_dim` was also added to the timer watchdog to be run every minute, it meant the panel was actually woken up every minute.

This change splits the dimming and the wakeup into two separate scripts, so the dimming can still be part of the watchdog, while the rest of the commands can do the wakeup and dim separately.