### PR TITLE
Fix `is_button_mask` calling

### DIFF
--- a/esphome/nspanel_esphome_standard_page_buttons.yaml
+++ b/esphome/nspanel_esphome_standard_page_buttons.yaml
@@ -67,7 +67,7 @@ api:
               display_component_update_visibility->execute(buttonpage_buttons[index].label, true);
 
               // Rendering button
-              if (is_button_in_mask(index, PageButtonsMaskEnabled)) {
+              if (is_button_in_mask(id, PageButtonsMaskEnabled)) {
                 page_buttonpage_button_renderer->execute(index, get_page_id(page.c_str()), component.c_str());
               }
             }
@@ -168,9 +168,10 @@ script:
           then:
             - lambda: |-
                 const uint8_t index = (current_page_id-${PAGE_ID_BUTTONPAGE01})*8 + iteration;
-                if (is_button_in_mask(index, PageButtonsMaskEnabled)) {
+                const uint8_t button_id = static_cast<uint8_t>(iteration + 1);
+                if (is_button_in_mask(button_id, PageButtonsMaskEnabled)) {
                   char component[10];
-                  snprintf(component, sizeof(component), "button%02" PRIu8, static_cast<uint8_t>(iteration + 1));
+                  snprintf(component, sizeof(component), "button%02" PRIu8, button_id);
                   ESP_LOGD("${TAG_PAGE_BUTTONS}", "Update '%s.%s'", current_page->state.c_str(), component);
                   page_buttonpage_button_renderer->execute(index, current_page_id, component);
                 }
@@ -183,7 +184,7 @@ script:
       component: string
     then:
       - lambda: |-
-          if (is_button_in_mask(index, PageButtonsMaskEnabled)) {
+          if (is_button_in_mask(index + 1, PageButtonsMaskEnabled)) {
             page_buttonpage_button_renderer_state->execute(index, page_id, component.c_str());
             page_buttonpage_button_renderer_visibility->execute(index, page_id, component.c_str());
           }
@@ -220,7 +221,7 @@ script:
     then:
       - lambda: |-
           if (page_id == current_page_id) {
-            const bool is_button_visible = is_button_in_mask(index, PageButtonsMaskEnabled);
+            const bool is_button_visible = is_button_in_mask(index + 1, PageButtonsMaskEnabled);
             set_component_visibility->execute(page_id, (component + "pic").c_str(), is_button_visible);
             set_component_visibility->execute(page_id, component.c_str(), is_button_visible);
           }


### PR DESCRIPTION
In `is_button_in_mask` the first parameter is a `button_id`, so starts with 1. Index however starts with 0. Changes makes sure we use 1-indexed values throughout, so the fields align properly