### PR TITLE
Use a better name for ota http based

### DIFF
--- a/docs/customization.md
+++ b/docs/customization.md
@@ -204,7 +204,7 @@ ota:
 ```
 
 ### Web server credentials
-By default, the web server credentials are defined by this project using `admin` as `username` and your `Wi-Fi password` as `password`, but you can replace it using this customization:
+By default, the web server credentials are defined by this project (advanced only) using `admin` as `username` and your `Wi-Fi password` as `password`, but you can replace it using this customization:
 
 ```yaml
 # Custom web server credentials
@@ -548,6 +548,8 @@ time:
 > When switching between frameworks, make sure to update the device with a serial cable as the partition table is different between the two frameworks
 as [OTA Update Component](https://esphome.io/components/ota) updates will not change the partition table. While it will appear to work, the device will boot the old framework after a reset.
 
+If you have absolute need to change framework via OTA, please ensure you flash your device twice in a row to increase the chances to have both partitions with the new firmware.
+
 This project currently uses `esp-idf` as default framework.
 You can overlap the settings with this customization.
 
@@ -715,10 +717,10 @@ switch:
 This can be useful to free-up memory, so other custom components could be used instead.
 
 ```yaml
-# Removes captive portal
+# Removes captive portal - Pre-built and advanced only
 captive_portal: !remove
 
-# Removes embedded web server
+# Removes embedded web server - Advanced only
 web_server: !remove
 ```
 

--- a/prebuilt/nspanel_esphome_prebuilt.yaml
+++ b/prebuilt/nspanel_esphome_prebuilt.yaml
@@ -85,7 +85,7 @@ logger:
 ota:
   - id: !extend ota_std
     password: !remove
-  - id: ota_web
+  - id: ota_http
     platform: http_request
 
 select:


### PR DESCRIPTION
To not mix with the new platform `ota.web_server`.

- #2668