### PR TITLE
Do not call `check_versions` from `global_settings`

### DIFF
--- a/esphome/nspanel_esphome_core.yaml
+++ b/esphome/nspanel_esphome_core.yaml
@@ -1491,8 +1491,8 @@ script:
           disp1->set_component_text_printf("ver_blueprint", "Blueprint: %s", blueprint_version.c_str());
       - lambda: |-
           ESP_LOGD("script.global_settings", "Checking versions");
-      - delay: ${DELAY_DEFAULT}ms
-      - script.execute: check_versions
+      #- delay: ${DELAY_DEFAULT}ms
+      #- script.execute: check_versions
 
       # MUI strings
       - lambda: |-


### PR DESCRIPTION
It will be called anyways from the sensor changing value