### PR TITLE
v4.3.33 - fix delayed relay chip refresh 

### DIFF
--- a/esphome/nspanel_esphome_core.yaml
+++ b/esphome/nspanel_esphome_core.yaml
@@ -537,6 +537,7 @@ script:  # Scripts
                   - lambda: return (relay_mask & 1);
                 then:
                   - lambda: |-
+                      add_component_visibility(${PAGE_HOME_ID}, "chip_relay1", relay_1->state);
                       disp1->set_component_text("home.chip_relay1",
                                                 (relay_1->state) ? id(home_relay1_icon).c_str() : "\uFFFF");
             # Chip - Relay 2
@@ -545,6 +546,7 @@ script:  # Scripts
                   - lambda: return (relay_mask & 2);
                 then:
                   - lambda: |-
+                      add_component_visibility(${PAGE_HOME_ID}, "chip_relay2", relay_2->state);
                       disp1->set_component_text("home.chip_relay2",
                                                 (relay_2->state) ? id(home_relay2_icon).c_str() : "\uFFFF");
 


### PR DESCRIPTION
After the last update v4.3.33 the new ( identical ) if statement block was creating an issue with both relay(1+2) chips of the home screen. 

For a fraction of second they were appearing and afterwards they will disappear. 
That behavior was observed every time you change to the home screen.
Reverting back to the if-condition-then statement seems its invocation is faster than a bigger if statement block in a lamda