### PR TITLE
fix: Initialize relay chips with correct state-based colors on boot | v4.3.40

### DIFF
--- a/esphome/nspanel_esphome_boot.yaml
+++ b/esphome/nspanel_esphome_boot.yaml
@@ -116,6 +116,9 @@ script:
           // Setup Home page
           boot_log->execute("Boot", "Set Home page elements");
 
+          // Refresh relay chips with correct state-based colors after blueprint settings are received
+          refresh_relays->execute(3);
+
           // Feed watchdog
           delay(${DELAY_SHORT});
           App.feed_wdt();
@@ -141,8 +144,9 @@ script:
           disp1->set_component_font("home.bt_qrcode", id(home_custom_buttons_font_id));
           disp1->set_component_font("home.bt_entities", id(home_custom_buttons_font_id));
           disp1->set_component_font("home.wifi_icon", id(home_chip_font_id));
-          disp1->set_component_font_color("home.chip_relay1", id(home_relay1_icon_color));
-          disp1->set_component_font_color("home.chip_relay2", id(home_relay2_icon_color));
+          // Set relay chips to invisible initially (will be updated by refresh_relays when home page loads)
+          disp1->set_component_font_color("home.chip_relay1", uint16_t(0));
+          disp1->set_component_font_color("home.chip_relay2", uint16_t(0));
 
           // Feed watchdog
           delay(${DELAY_SHORT});

--- a/esphome/nspanel_esphome_core.yaml
+++ b/esphome/nspanel_esphome_core.yaml
@@ -175,10 +175,10 @@ script:  # Scripts
           if (page == "mem") {
             if (component == "relay1_icon_color") {
               id(home_relay1_icon_color) = color;
-              disp1->set_component_font_color("home.chip_relay1", color);
+              // Don't set display color here - let refresh_relays handle it based on relay state
             } else if (component == "relay2_icon_color") {
-              id(home_relay1_icon_color) = color;
-              disp1->set_component_font_color("home.chip_relay2", color);
+              id(home_relay2_icon_color) = color;
+              // Don't set display color here - let refresh_relays handle it based on relay state
             }
           }
 


### PR DESCRIPTION
## Problem

After device restart, relay 1 and relay 2 chips were always showing visible on home screen even when both relays were actually off. This was confusing because the display was not matching the real relay states.

## What was happening

There were 3 issues causing this:

- During boot, relay chips were getting set to their configured colors first, then later the refresh script would make them invisible. This caused a timing issue.
- When blueprint sends relay colors via component_color action, it was immediately updating the display colors, which was overriding our invisible setting.
- There was a small bug in relay2 color handler - it was setting wrong variable (relay1 instead of relay2).

## Fix applied

- Changed boot sequence to set relay chips as invisible (color 0) initially instead of configured colors
- Modified component_color handler to only store the colors but not update display immediately  
- Added refresh_relays call after blueprint settings are received so correct colors get applied
- There was a small bug in relay2 color handler - it was setting wrong variable (relay1 instead of relay2).

## Files changed
- `esphome/nspanel_esphome_boot.yaml` - Set invisible initially and add refresh call
- `esphome/nspanel_esphome_core.yaml` - Remove immediate display update and fix variable bug

## Result

Now relay chips work properly:

- When relays are OFF → chips are invisible 
- When relays are ON → chips show with correct colors
- No more timing issues or brief visibility during boot
