### PR TITLE
Alarm Control Panel Crash on ESPHome 2025.10.0+

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -44,9 +44,9 @@ updates on the home page for QR code and utilities page access.
 - Adopted in: v202510.0 (short-lived)
 
 **New format (v2025111):**
-- Format: `yyyymmx` (year, month, zero-padded sequential starting from 01)
-- First release of month: `yyyymm1` (e.g., `2025110` for first November 2025 release)
-- Second release: `2025111`, then `20251102`, etc.
+- Format: `yyyymmx` (year, month, zero-padded sequential starting from 0)
+- First release of month: `yyyymm0` (e.g., `2025110` for first November 2025 release)
+- Second release: `2025111`, then `2025112`, etc.
 - Sequential counter: 0-9
 - Pure integer format avoids floating-point issues
 
@@ -126,6 +126,21 @@ function correctly when disconnected from Blueprint data.
 **Issues Reference:** #3012
 
 **Result:** Panel now operates correctly in offline mode when not receiving data from Blueprint.
+
+### Alarm Control Panel Crash on ESPHome 2025.10.0+
+
+**Fixed panel crashing when calling alarm_control_panel actions** - resolved crash issue that
+occurred when using alarm control panel actions on ESPHome 2025.10.0 and later versions.
+
+**Issue details:**
+- Alarm control panel actions caused panel crashes on ESPHome 2025.10.0+
+- Worked correctly on previous ESPHome versions
+- Breaking change in ESPHome API required code adjustment
+
+**Issues Reference:** #2972
+
+**Result:** Alarm control panel actions now work correctly on ESPHome 2025.10.0+ without
+crashing.
 
 ---
 

--- a/esphome/nspanel_esphome_page_alarm.yaml
+++ b/esphome/nspanel_esphome_page_alarm.yaml
@@ -77,8 +77,8 @@ api:
               ESP_LOGV("${TAG_PAGE_ALARM}", "Button - Home");
               const bool is_armed_home = (state == "armed_home");
               disp1->set_component_pic("bt_home_pic", is_armed_home ? 43 : 42);
-              disp1->set_component_background_color("bt_home_text", is_armed_home ? Colors::GREEN : Colors::PURPLE_MEDIUM);
-              disp1->set_component_background_color("bt_home_icon", is_armed_home ? Colors::GREEN : Colors::PURPLE_MEDIUM);
+              disp1->set_component_background_color("bt_home_text", is_armed_home ? Colors::GREEN : Colors::GRAY_LIGHT);
+              disp1->set_component_background_color("bt_home_icon", is_armed_home ? Colors::GREEN : Colors::GRAY_LIGHT);
               disp1->set_component_font_color("bt_home_text", is_armed_home ? Colors::WHITE : Colors::BLACK);
               disp1->set_component_font_color("bt_home_icon", is_armed_home ? Colors::WHITE : Colors::BLACK);
               #ifdef USE_REQUIRE_DISARM_BEFORE_REARM
@@ -94,8 +94,8 @@ api:
               ESP_LOGV("${TAG_PAGE_ALARM}", "Button - Away");
               const bool is_armed_away = (state == "armed_away");
               disp1->set_component_pic("bt_away_pic", is_armed_away ? 43 : 42);
-              disp1->set_component_background_color("bt_away_text", is_armed_away ? Colors::GREEN : Colors::PURPLE_MEDIUM);
-              disp1->set_component_background_color("bt_away_icon", is_armed_away ? Colors::GREEN : Colors::PURPLE_MEDIUM);
+              disp1->set_component_background_color("bt_away_text", is_armed_away ? Colors::GREEN : Colors::GRAY_LIGHT);
+              disp1->set_component_background_color("bt_away_icon", is_armed_away ? Colors::GREEN : Colors::GRAY_LIGHT);
               disp1->set_component_font_color("bt_away_text", is_armed_away ? Colors::WHITE : Colors::BLACK);
               disp1->set_component_font_color("bt_away_icon", is_armed_away ? Colors::WHITE : Colors::BLACK);
               #ifdef USE_REQUIRE_DISARM_BEFORE_REARM
@@ -111,8 +111,8 @@ api:
               ESP_LOGV("${TAG_PAGE_ALARM}", "Button - Night");
               const bool is_armed_night = (state == "armed_night");
               disp1->set_component_pic("bt_night_pic", is_armed_night ? 43 : 42);
-              disp1->set_component_background_color("bt_night_text", is_armed_night ? Colors::GREEN : Colors::PURPLE_MEDIUM);
-              disp1->set_component_background_color("bt_night_icon", is_armed_night ? Colors::GREEN : Colors::PURPLE_MEDIUM);
+              disp1->set_component_background_color("bt_night_text", is_armed_night ? Colors::GREEN : Colors::GRAY_LIGHT);
+              disp1->set_component_background_color("bt_night_icon", is_armed_night ? Colors::GREEN : Colors::GRAY_LIGHT);
               disp1->set_component_font_color("bt_night_text", is_armed_night ? Colors::WHITE : Colors::BLACK);
               disp1->set_component_font_color("bt_night_icon", is_armed_night ? Colors::WHITE : Colors::BLACK);
               #ifdef USE_REQUIRE_DISARM_BEFORE_REARM
@@ -127,8 +127,8 @@ api:
               ESP_LOGV("${TAG_PAGE_ALARM}", "Button - Vacation");
               const bool is_armed_vacation = (state == "armed_vacation");
               disp1->set_component_pic("bt_vacat_pic", is_armed_vacation ? 43 : 42);
-              disp1->set_component_background_color("bt_vacat_text", is_armed_vacation ? Colors::GREEN : Colors::PURPLE_MEDIUM);
-              disp1->set_component_background_color("bt_vacat_icon", is_armed_vacation ? Colors::GREEN : Colors::PURPLE_MEDIUM);
+              disp1->set_component_background_color("bt_vacat_text", is_armed_vacation ? Colors::GREEN : Colors::GRAY_LIGHT);
+              disp1->set_component_background_color("bt_vacat_icon", is_armed_vacation ? Colors::GREEN : Colors::GRAY_LIGHT);
               disp1->set_component_font_color("bt_vacat_text", is_armed_vacation ? Colors::WHITE : Colors::BLACK);
               disp1->set_component_font_color("bt_vacat_icon", is_armed_vacation ? Colors::WHITE : Colors::BLACK);
               #ifdef USE_REQUIRE_DISARM_BEFORE_REARM
@@ -144,8 +144,8 @@ api:
               ESP_LOGV("${TAG_PAGE_ALARM}", "Button - Custom bypass");
               const bool is_triggered_custom_bypass = (state == "armed_custom_bypass");
               disp1->set_component_pic("bt_bypass_pic", is_triggered_custom_bypass ? 43 : 42);
-              disp1->set_component_background_color("bt_bypass_text", is_triggered_custom_bypass ? Colors::GREEN : Colors::PURPLE_MEDIUM);
-              disp1->set_component_background_color("bt_bypass_icon", is_triggered_custom_bypass ? Colors::GREEN : Colors::PURPLE_MEDIUM);
+              disp1->set_component_background_color("bt_bypass_text", is_triggered_custom_bypass ? Colors::GREEN : Colors::GRAY_LIGHT);
+              disp1->set_component_background_color("bt_bypass_icon", is_triggered_custom_bypass ? Colors::GREEN : Colors::GRAY_LIGHT);
               disp1->set_component_font_color("bt_bypass_text", is_triggered_custom_bypass ? Colors::WHITE : Colors::BLACK);
               disp1->set_component_font_color("bt_bypass_icon", is_triggered_custom_bypass ? Colors::WHITE : Colors::BLACK);
               #ifdef USE_REQUIRE_DISARM_BEFORE_REARM
@@ -160,8 +160,8 @@ api:
             ESP_LOGV("${TAG_PAGE_ALARM}", "Button - Disarm");
             const bool is_disarmed = (state == "disarmed");
             disp1->set_component_pic("bt_disarm_pic", is_disarmed ? 43 : 42);
-            disp1->set_component_background_color("bt_disarm_text", is_disarmed ? Colors::GREEN : Colors::PURPLE_MEDIUM);
-            disp1->set_component_background_color("bt_disarm_icon", is_disarmed ? Colors::GREEN : Colors::PURPLE_MEDIUM);
+            disp1->set_component_background_color("bt_disarm_text", is_disarmed ? Colors::GREEN : Colors::GRAY_LIGHT);
+            disp1->set_component_background_color("bt_disarm_icon", is_disarmed ? Colors::GREEN : Colors::GRAY_LIGHT);
             disp1->set_component_font_color("bt_disarm_text", is_disarmed ? Colors::WHITE : Colors::BLACK);
             disp1->set_component_font_color("bt_disarm_icon", is_disarmed ? Colors::WHITE : Colors::BLACK);
             disp1->send_command_printf("vis bt_disarm,%i", (is_disarmed) ? 0 : 1);
@@ -234,11 +234,19 @@ script:
           action += key;
           ESP_LOGV("${TAG_PAGE_ALARM}", "  action: %s", action.c_str());
 
-          #if ESPHOME_VERSION_CODE < VERSION_CODE(2025, 10, 0)  // Code for ESPHome earlier than v2025.10.0
+          // Create action request based on ESPHome version
+          #if ESPHOME_VERSION_CODE < VERSION_CODE(2025, 10, 0)  // ESPHome earlier than v2025.10.0
+          ESP_LOGV("${TAG_PAGE_ALARM}", "Using HomeassistantServiceResponse (ESPHome < 2025.10.0)");
           esphome::api::HomeassistantServiceResponse action_request;
+          #else  // ESPHome v2025.10.0 or newer
+          ESP_LOGV("${TAG_PAGE_ALARM}", "Using HomeassistantActionRequest (ESPHome >= 2025.10.0)");
+          esphome::api::HomeassistantActionRequest action_request;
+          #endif  // ESPHome version check
+
           action_request.set_service(StringRef(action));
 
           // Add entity_id parameter
+          ESP_LOGV("${TAG_PAGE_ALARM}", "Adding entity_id parameter");
           esphome::api::HomeassistantServiceMap kv_entity;
           kv_entity.set_key(StringRef("entity_id"));
           kv_entity.value = entity;
@@ -246,35 +254,22 @@ script:
 
           // Add code parameter if pin is provided
           if (!pin.empty()) {
+            ESP_LOGV("${TAG_PAGE_ALARM}", "Adding code parameter");
             esphome::api::HomeassistantServiceMap kv_code;
             kv_code.set_key(StringRef("code"));
             kv_code.value = pin;
             action_request.data.push_back(kv_code);
           }
 
+          // Send action call to Home Assistant
+          ESP_LOGV("${TAG_PAGE_ALARM}", "Sending action call to Home Assistant");
+          #if ESPHOME_VERSION_CODE < VERSION_CODE(2025, 10, 0)  // ESPHome earlier than v2025.10.0
           global_api_server->send_homeassistant_service_call(action_request);
-          #else  // Code for ESPHome v2025.10.0 or newer
-          esphome::api::HomeassistantActionRequest action_request;
-          action_request.set_service(StringRef(action));
-
-          // Add entity_id parameter
-          action_request.data.emplace_back();
-          auto &kv_entity = action_request.data.back();
-          kv_entity.set_key(StringRef("entity_id"));
-          kv_entity.value = entity;
-
-          // Add code parameter if pin is provided
-          if (!pin.empty()) {
-            action_request.data.emplace_back();
-            auto &kv_code = action_request.data.back();
-            kv_code.set_key(StringRef("code"));
-            kv_code.value = pin;
-          }
-
+          #else  // ESPHome v2025.10.0 or newer
           api_server->send_homeassistant_action(action_request);
-          #endif  // ESPHome version based code
+          #endif  // ESPHome version check
 
-          ESP_LOGVV("${TAG_PAGE_ALARM}", "Alarm control panel action called");
+          ESP_LOGV("${TAG_PAGE_ALARM}", "Alarm control panel action completed");
 
   - id: !extend dump_config  # Defined by nspanel_esphome_core_base.yaml
     then:


### PR DESCRIPTION
**Fixed panel crashing when calling alarm_control_panel actions** - resolved crash issue that
occurred when using alarm control panel actions on ESPHome 2025.10.0 and later versions.

**Issue details:**
- Alarm control panel actions caused panel crashes on ESPHome 2025.10.0+
- Worked correctly on previous ESPHome versions
- Breaking change in ESPHome API required code adjustment

**Issues Reference:** #2972

**Result:** Alarm control panel actions now work correctly on ESPHome 2025.10.0+ without
crashing.