### PR TITLE
Reset overlaps for `chip_climate`

### DIFF
--- a/esphome/nspanel_esphome_addon_climate_base.yaml
+++ b/esphome/nspanel_esphome_addon_climate_base.yaml
@@ -371,10 +371,10 @@ script:
       mode: uint
     then:
       - lambda: |-
-          ESP_LOGV("${TAG_CORE}", "Update climate icon");
-          ESP_LOGV("${TAG_CORE}", "  component: %s", component.c_str());
-          ESP_LOGV("${TAG_CORE}", "  action: %d", action);
-          ESP_LOGV("${TAG_CORE}", "  mode: %d", mode);
+          ESP_LOGV("${TAG_ADDON_CLIMATE}", "Update climate icon");
+          ESP_LOGV("${TAG_ADDON_CLIMATE}", "  component: %s", component.c_str());
+          ESP_LOGV("${TAG_ADDON_CLIMATE}", "  action: %d", action);
+          ESP_LOGV("${TAG_ADDON_CLIMATE}", "  mode: %d", mode);
 
           const char* icon = Icons::NONE;
           uint16_t color = Colors::BLACK;
@@ -408,7 +408,7 @@ script:
             target_id = full_id;
           }
 
-          ESP_LOGV("${TAG_CORE}", "  target: %s", target_id);
+          ESP_LOGV("${TAG_ADDON_CLIMATE}", "  target: %s", target_id);
 
           // Apply the icon and color to the display component
           disp1->set_component_text(target_id, icon);

--- a/nspanel_blueprint.yaml
+++ b/nspanel_blueprint.yaml
@@ -9534,6 +9534,10 @@ action:
                             then:
                               - variables:
                                   entity_id: '{{ climate }}'
+                                  overlap:
+                                    icon: '{{ None }}'
+                                    icon_color: '{{ None }}'
+                                    name: '{{ None }}'
                               - *variable_entity
                               - condition: '{{ entity_id_valid }}'
                               - variables:


### PR DESCRIPTION
When called directly, the overlaps are using the default (`None`) and then this works fine, but when constructing the page `home`, this is called right after the `button07` and then if the overlaps are not reset it will use the last one used, displaying the icon for `button07` regardless of the climate status.

Hopefully this:
- fixes #2521
- fixes #2684