### PR TITLE
prebuild ESPhome 2025 compatibility fixes

### DIFF
--- a/prebuilt/nspanel_esphome_prebuilt.yaml
+++ b/prebuilt/nspanel_esphome_prebuilt.yaml
@@ -16,18 +16,19 @@ substitutions:
 
 packages:
   core_package: !include ../esphome/nspanel_esphome_core.yaml
+  standard: !include ../esphome/nspanel_esphome_standard.yaml
   upload_tft_package: !include ../esphome/nspanel_esphome_addon_upload_tft.yaml
 
 api:
-  services:
-    - service: firmware_update
+  actions:
+    - action: firmware_update
       variables:
         url: string
       then:
         - ota.http_request.flash:
             md5_url: !lambda return fw_url->state + ".md5";
             url: !lambda return fw_url->state;
-        - lambda: ESP_LOGE("prebuilt.api.service.firmware_update", "Firmware update failed!");
+        - lambda: ESP_LOGE("prebuilt.api.action.firmware_update", "Firmware update failed!");
 
 button:
   - name: Factory reset
@@ -55,8 +56,6 @@ dashboard_import:
 esp32:
   framework:
     type: esp-idf
-    version: 4.4.8
-    platform_version: 5.4.0
 
 esp32_ble:
   id: ble


### PR DESCRIPTION
add nspanel_esphome_standard.yaml to the prebuild yaml and migrate firmware_update service to an action to fix compile errors