### PR TITLE
Translate alarm page home button text per localization

### DIFF
--- a/esphome/nspanel_esphome_page_alarm.yaml
+++ b/esphome/nspanel_esphome_page_alarm.yaml
@@ -117,6 +117,7 @@ api:
 
             // Buttons - Text
             ESP_LOGV("${TAG_PAGE_ALARM}", "Buttons - Text");
+            disp1->set_component_text("bt_home_text", wrapText(mui_alarm[0].c_str(), 10, id(mui_bytes_per_char)).c_str());
             disp1->set_component_text("bt_away_text", wrapText(mui_alarm[1].c_str(), 10, id(mui_bytes_per_char)).c_str());
             disp1->set_component_text("bt_night_text", wrapText(mui_alarm[2].c_str(), 10, id(mui_bytes_per_char)).c_str());
             disp1->set_component_text("bt_vacat_text", wrapText(mui_alarm[3].c_str(), 10, id(mui_bytes_per_char)).c_str());


### PR DESCRIPTION
The "Home" button on the alarm page was not being translated per localization language settings