### PR TITLE
Update nspanel_esphome_hw_temperature.yaml

### DIFF
--- a/esphome/nspanel_esphome_hw_temperature.yaml
+++ b/esphome/nspanel_esphome_hw_temperature.yaml
@@ -36,10 +36,10 @@ number:
     platform: template
     entity_category: config
     unit_of_measurement: ${'°F' if TEMP_UNIT_IS_FAHRENHEIT else '°C'}
-    min_value: ${-18.0 if TEMP_UNIT_IS_FAHRENHEIT else -10.0}
-    max_value: ${18.0 if TEMP_UNIT_IS_FAHRENHEIT else 10.0}
+    min_value: ${ -18.0 if TEMP_UNIT_IS_FAHRENHEIT else -10.0 }
+    max_value: ${ 18.0 if TEMP_UNIT_IS_FAHRENHEIT else 10.0 }
     initial_value: 0
-    step: ${1.0 if TEMP_UNIT_IS_FAHRENHEIT else 0.1}
+    step: ${ 1.0 if TEMP_UNIT_IS_FAHRENHEIT else 0.1 }
     mode: box
     restore_value: true
     internal: false


### PR DESCRIPTION
When using Fahrenheit temperature units (temp_units: "°F"), the ESPHome compilation fails with the following error:

esphome/nspanel_esphome_hw_temperature.yaml. The degree symbols are corrupted as Â° instead of proper °, causing the temperature unit comparison to fail.

Affected Users: All users attempting to configure climate control with Fahrenheit temperature units
Related Issues: This may be related to bug #3137 mentioned in the v2026010 changelog, as both involve temperature value handling